### PR TITLE
make liq limit configurable

### DIFF
--- a/env.example
+++ b/env.example
@@ -63,3 +63,6 @@ PERP_DEFAULT_TICK_UPPER=23030
 
 # Liquidity scaling factor (multiplier to convert USDC margin to 18-decimal liquidity)
 PERP_LIQUIDITY_SCALING_FACTOR=400000000000000
+
+# Maximum margin amount per perp in USDC (6 decimals, e.g., 5 USDC = 5000000)
+PERP_MAX_MARGIN_PER_PERP_USDC=5000000

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,10 @@ fn load_perp_config() -> PerpConfig {
             "PERP_LIQUIDITY_SCALING_FACTOR",
             default_config.liquidity_scaling_factor,
         ),
+        max_margin_per_perp_usdc: parse_env_or_default(
+            "PERP_MAX_MARGIN_PER_PERP_USDC",
+            default_config.max_margin_per_perp_usdc,
+        ),
     }
 }
 
@@ -192,6 +196,10 @@ pub async fn create_rocket() -> Rocket<Build> {
         "  - Funding interval: {}s ({}h)",
         perp_config.funding_interval_seconds,
         perp_config.funding_interval_seconds / 3600
+    );
+    tracing::info!(
+        "  - Max margin per perp: {} USDC",
+        perp_config.max_margin_per_perp_usdc as f64 / 1_000_000.0
     );
 
     // Get environment configuration

--- a/src/models.rs
+++ b/src/models.rs
@@ -175,6 +175,8 @@ pub struct PerpConfig {
     pub default_tick_upper: i32,
     /// Liquidity scaling factor (multiplier to convert USDC margin to 18-decimal liquidity)
     pub liquidity_scaling_factor: u128,
+    /// Maximum margin amount per perp in USDC (6 decimals)
+    pub max_margin_per_perp_usdc: u128,
 }
 
 impl Default for PerpConfig {
@@ -195,6 +197,7 @@ impl Default for PerpConfig {
             default_tick_lower: -23030,                               // Approx sqrt(0.1) price
             default_tick_upper: 23030,                                // Approx sqrt(10) price
             liquidity_scaling_factor: 400_000_000_000_000,            // Scale USDC to 18 decimals
+            max_margin_per_perp_usdc: 5_000_000,                      // 5 USDC in 6 decimals
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Margin limits for perpetual contracts are now configurable, allowing the maximum margin per contract in USDC to be set via an environment variable.

* **Bug Fixes**
  * Error messages for margin violations now accurately display the configured margin limit.

* **Chores**
  * Updated environment configuration to include a new parameter for setting the maximum margin per perpetual contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->