### PR TITLE
Change proof and public_signals to byte arrays in update beacon API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Strobe Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/models/requests.rs
+++ b/src/models/requests.rs
@@ -1,17 +1,18 @@
+use alloy::primitives::Bytes;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateBeaconRequest {
     pub beacon_address: String,
-    pub proof: Vec<u8>,          // ZK proof as byte array
-    pub public_signals: Vec<u8>, // Public signals as byte array (contains the new data value)
+    pub proof: Bytes,          // 0x-hex in JSON
+    pub public_signals: Bytes, // 0x-hex in JSON (contains the new data value)
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BeaconUpdateData {
     pub beacon_address: String,
-    pub proof: Vec<u8>,          // ZK proof as byte array
-    pub public_signals: Vec<u8>, // Public signals as byte array
+    pub proof: Bytes,          // 0x-hex in JSON
+    pub public_signals: Bytes, // 0x-hex in JSON
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/services/beacon/batch.rs
+++ b/src/services/beacon/batch.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, Bytes};
+use alloy::primitives::Address;
 use std::str::FromStr;
 
 use crate::models::{
@@ -193,9 +193,9 @@ async fn batch_update_with_multicall3(
             }
         };
 
-        // Convert proof and public signals byte arrays to Bytes
-        let proof_bytes = Bytes::from(update_data.proof.clone());
-        let public_signals_bytes = Bytes::from(update_data.public_signals.clone());
+        // proof and public_signals are already Bytes (from 0x-hex JSON)
+        let proof_bytes = update_data.proof.clone();
+        let public_signals_bytes = update_data.public_signals.clone();
 
         // Create the updateData call data using the IBeacon interface
         let beacon_contract = IBeacon::new(beacon_address, &*state.provider);

--- a/src/services/beacon/core.rs
+++ b/src/services/beacon/core.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256, Bytes};
+use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
 use std::{str::FromStr, time::Duration};
 use tokio::time::timeout;
@@ -619,11 +619,9 @@ pub async fn update_beacon(state: &AppState, request: UpdateBeaconRequest) -> Re
 
     tracing::info!("Updating beacon {} with proof data", beacon_address);
 
-    // Convert proof byte array to Bytes
-    let proof_bytes = Bytes::from(request.proof);
-
-    // Convert public signals byte array to Bytes
-    let public_signals_bytes = Bytes::from(request.public_signals);
+    // proof and public_signals are already Bytes (from 0x-hex JSON)
+    let proof_bytes = request.proof;
+    let public_signals_bytes = request.public_signals;
 
     // Create contract instance using the sol! generated interface
     let contract = IBeacon::new(beacon_address, &*state.provider);

--- a/tests/integration_tests/beacon_core_integration_tests.rs
+++ b/tests/integration_tests/beacon_core_integration_tests.rs
@@ -99,11 +99,10 @@ async fn test_update_beacon_integration() {
     // Create update request
     let update_request = UpdateBeaconRequest {
         beacon_address: beacon_address.to_string(),
-        proof: hex::decode("0102030405060708").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000003039",
-        )
-        .unwrap(), // 12345 in hex
+        proof: "0x0102030405060708".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000003039"
+            .parse()
+            .unwrap(), // 12345 in hex
     };
 
     // Update beacon with proof
@@ -263,11 +262,10 @@ async fn test_beacon_operations_error_handling() {
     // Test invalid update request
     let invalid_update = UpdateBeaconRequest {
         beacon_address: "invalid_address".to_string(),
-        proof: hex::decode("01020304").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(), // 100 in hex
+        proof: "0x01020304".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(), // 100 in hex
     };
 
     let update_result = update_beacon(&app_state, invalid_update).await;

--- a/tests/unit_tests/beacon_tests.rs
+++ b/tests/unit_tests/beacon_tests.rs
@@ -31,11 +31,10 @@ async fn test_batch_update_beacon_with_multicall3() {
 
     let update_data = BeaconUpdateData {
         beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-        proof: hex::decode("01020304").unwrap(), // Mock proof as bytes
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(), // 100 encoded as bytes
+        proof: "0x01020304".parse().unwrap(), // Mock proof as bytes
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(), // 100 encoded as bytes
     };
 
     let request = Json(BatchUpdateBeaconRequest {
@@ -66,11 +65,10 @@ async fn test_batch_update_beacon_without_multicall3() {
 
     let update_data = BeaconUpdateData {
         beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-        proof: hex::decode("01020304").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(),
+        proof: "0x01020304".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(),
     };
 
     let request = Json(BatchUpdateBeaconRequest {
@@ -134,11 +132,10 @@ fn test_multicall3_atomic_behavior() {
     // Test that multicall3 calls are atomic (allowFailure: false)
     let update_data = BeaconUpdateData {
         beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-        proof: hex::decode("01020304").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(),
+        proof: "0x01020304".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(),
     };
 
     // Create mock multicall3 call and verify atomicity setting

--- a/tests/unit_tests/services_beacon_core_tests.rs
+++ b/tests/unit_tests/services_beacon_core_tests.rs
@@ -12,11 +12,10 @@ async fn test_update_beacon_invalid_address() {
 
     let request = UpdateBeaconRequest {
         beacon_address: "invalid_address".to_string(),
-        proof: hex::decode("01020304").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(), // 100 in hex, padded to 32 bytes
+        proof: "0x01020304".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(), // 100 in hex, padded to 32 bytes
     };
 
     let result = update_beacon(&app_state, request).await;
@@ -80,11 +79,10 @@ async fn test_update_beacon_empty_address() {
 
     let request = UpdateBeaconRequest {
         beacon_address: "".to_string(),
-        proof: hex::decode("01020304").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(),
+        proof: "0x01020304".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(),
     };
 
     let result = update_beacon(&app_state, request).await;
@@ -99,11 +97,10 @@ async fn test_update_beacon_zero_address() {
 
     let request = UpdateBeaconRequest {
         beacon_address: "0x0000000000000000000000000000000000000000".to_string(),
-        proof: hex::decode("01020304").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(),
+        proof: "0x01020304".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(),
     };
 
     // Valid address format, but should fail deterministically at network level
@@ -118,11 +115,10 @@ async fn test_update_beacon_max_address() {
 
     let request = UpdateBeaconRequest {
         beacon_address: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".to_string(),
-        proof: hex::decode("01020304").unwrap(),
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000064",
-        )
-        .unwrap(),
+        proof: "0x01020304".parse().unwrap(),
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+            .parse()
+            .unwrap(),
     };
 
     // Valid address format, but should fail deterministically at network level
@@ -135,25 +131,24 @@ async fn test_update_beacon_various_proof_sizes() {
     let mock_provider = crate::test_utils::create_mock_provider_with_network_error();
     let app_state = crate::test_utils::create_test_app_state_with_provider(mock_provider);
 
-    let large_proof_bytes = vec![0xff; 100];
-    let very_large_proof_bytes = vec![0x00; 1000];
+    let large_proof = format!("0x{}", "ff".repeat(100));
+    let very_large_proof = format!("0x{}", "00".repeat(1000));
 
     let test_proofs = vec![
-        vec![],                         // Empty proof
-        vec![0x00],                     // Single byte
-        vec![0x01, 0x02, 0x03],         // Small proof
-        large_proof_bytes.clone(),      // Large proof
-        very_large_proof_bytes.clone(), // Very large proof
+        "0x",                      // Empty proof
+        "0x00",                    // Single byte
+        "0x010203",                // Small proof
+        large_proof.as_str(),      // Large proof
+        very_large_proof.as_str(), // Very large proof
     ];
 
-    for proof in test_proofs {
+    for proof_hex in test_proofs {
         let request = UpdateBeaconRequest {
             beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-            proof: proof.clone(),
-            public_signals: hex::decode(
-                "0000000000000000000000000000000000000000000000000000000000000064",
-            )
-            .unwrap(),
+            proof: proof_hex.parse().unwrap(),
+            public_signals: "0x0000000000000000000000000000000000000000000000000000000000000064"
+                .parse()
+                .unwrap(),
         };
 
         let result = update_beacon(&app_state, request).await;
@@ -168,18 +163,18 @@ async fn test_update_beacon_various_public_signals() {
     let app_state = crate::test_utils::create_test_app_state_with_provider(mock_provider);
 
     let test_public_signals = vec![
-        hex::decode("0000000000000000000000000000000000000000000000000000000000000000").unwrap(), // 0
-        hex::decode("0000000000000000000000000000000000000000000000000000000000000001").unwrap(), // 1
-        hex::decode("0000000000000000000000000000000000000000000000000000000000000064").unwrap(), // 100
-        hex::decode("00000000000000000000000000000000000000000000000000000000000003e8").unwrap(), // 1000
-        hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap(), // max u256
+        "0x0000000000000000000000000000000000000000000000000000000000000000", // 0
+        "0x0000000000000000000000000000000000000000000000000000000000000001", // 1
+        "0x0000000000000000000000000000000000000000000000000000000000000064", // 100
+        "0x00000000000000000000000000000000000000000000000000000000000003e8", // 1000
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // max u256
     ];
 
-    for public_signals in test_public_signals {
+    for public_signals_hex in test_public_signals {
         let request = UpdateBeaconRequest {
             beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-            proof: hex::decode("01020304").unwrap(),
-            public_signals: public_signals.clone(),
+            proof: "0x01020304".parse().unwrap(),
+            public_signals: public_signals_hex.parse().unwrap(),
         };
 
         let result = update_beacon(&app_state, request).await;
@@ -319,17 +314,18 @@ async fn test_register_beacon_with_registry_max_addresses() {
 fn test_update_beacon_request_validation() {
     let request = UpdateBeaconRequest {
         beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-        proof: hex::decode("0102030405").unwrap(),
-        public_signals: hex::decode(
-            "000000000000000000000000000000000000000000000000000000000000002a",
-        )
-        .unwrap(), // 42 in hex
+        proof: "0x0102030405".parse().unwrap(),
+        public_signals: "0x000000000000000000000000000000000000000000000000000000000000002a"
+            .parse()
+            .unwrap(), // 42 in hex
     };
 
-    assert_eq!(request.proof, vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+    assert_eq!(request.proof.as_ref(), &[0x01, 0x02, 0x03, 0x04, 0x05]);
     assert_eq!(
         request.public_signals,
-        hex::decode("000000000000000000000000000000000000000000000000000000000000002a").unwrap()
+        "0x000000000000000000000000000000000000000000000000000000000000002a"
+            .parse::<alloy::primitives::Bytes>()
+            .unwrap()
     );
     assert!(request.beacon_address.starts_with("0x"));
 }
@@ -338,11 +334,10 @@ fn test_update_beacon_request_validation() {
 fn test_update_beacon_request_serialization() {
     let request = UpdateBeaconRequest {
         beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-        proof: vec![0x0a, 0x14, 0x1e, 0x28, 0x32], // [10, 20, 30, 40, 50]
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000003039",
-        )
-        .unwrap(), // 12345 in hex
+        proof: "0x0a141e2832".parse().unwrap(), // [10, 20, 30, 40, 50]
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000003039"
+            .parse()
+            .unwrap(), // 12345 in hex
     };
 
     let json = serde_json::to_string(&request).unwrap();
@@ -358,11 +353,10 @@ fn test_update_beacon_request_edge_cases() {
     // Test max u256 value in public signals
     let request_max = UpdateBeaconRequest {
         beacon_address: "0x1234567890123456789012345678901234567890".to_string(),
-        proof: vec![0xff; 1000], // Large proof
-        public_signals: hex::decode(
-            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        )
-        .unwrap(), // max u256
+        proof: format!("0x{}", "ff".repeat(1000)).parse().unwrap(), // Large proof
+        public_signals: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            .parse()
+            .unwrap(), // max u256
     };
     assert_eq!(request_max.proof.len(), 1000); // 1000 bytes
     assert_eq!(request_max.public_signals.len(), 32); // 32 bytes (256 bits)
@@ -370,13 +364,12 @@ fn test_update_beacon_request_edge_cases() {
     // Test zero value
     let request_zero = UpdateBeaconRequest {
         beacon_address: "0x0000000000000000000000000000000000000000".to_string(),
-        proof: vec![], // Empty proof
-        public_signals: hex::decode(
-            "0000000000000000000000000000000000000000000000000000000000000000",
-        )
-        .unwrap(), // 0
+        proof: "0x".parse().unwrap(), // Empty proof
+        public_signals: "0x0000000000000000000000000000000000000000000000000000000000000000"
+            .parse()
+            .unwrap(), // 0
     };
-    assert_eq!(request_zero.proof, Vec::<u8>::new());
+    assert_eq!(request_zero.proof.len(), 0);
     assert_eq!(request_zero.public_signals.len(), 32); // 32 bytes
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Beacon update payloads now require ZK proofs and public signals as raw binary (bytes) instead of encoded text; provide binary data in integrations and requests.
* **Documentation**
  * Repository now includes an explicit MIT license file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->