### PR TITLE
Add missing logging for insufficient balance errors in fund_guest_wallet

### DIFF
--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -137,6 +137,20 @@ pub async fn fund_guest_wallet(
 
     // Check if we have enough ETH
     if eth_balance < U256::from(eth_amount) {
+        tracing::warn!(
+            "Insufficient ETH balance in funding wallet {}. Have: {} ETH, Need: {} ETH",
+            state.funding_wallet_address,
+            alloy::primitives::utils::format_ether(eth_balance),
+            alloy::primitives::utils::format_ether(U256::from(eth_amount))
+        );
+        sentry::capture_message(
+            &format!(
+                "Insufficient ETH balance in funding wallet. Have: {} ETH, Need: {} ETH",
+                alloy::primitives::utils::format_ether(eth_balance),
+                alloy::primitives::utils::format_ether(U256::from(eth_amount))
+            ),
+            sentry::Level::Warning,
+        );
         return Err((
             Status::InternalServerError,
             Json(ApiResponse {
@@ -178,6 +192,20 @@ pub async fn fund_guest_wallet(
 
     // Check if we have enough USDC
     if usdc_balance < U256::from(usdc_amount) {
+        tracing::warn!(
+            "Insufficient USDC balance in funding wallet {}. Have: {} USDC, Need: {} USDC",
+            state.funding_wallet_address,
+            usdc_balance / U256::from(1_000_000),
+            usdc_amount / 1_000_000
+        );
+        sentry::capture_message(
+            &format!(
+                "Insufficient USDC balance in funding wallet. Have: {} USDC, Need: {} USDC",
+                usdc_balance / U256::from(1_000_000),
+                usdc_amount / 1_000_000
+            ),
+            sentry::Level::Warning,
+        );
         return Err((
             Status::InternalServerError,
             Json(ApiResponse {


### PR DESCRIPTION
## Summary
- The `fund_guest_wallet` endpoint's insufficient ETH/USDC balance error paths returned 500 without any server-side logging or Sentry alerts
- Every other error path in the handler had `tracing::error!` and `sentry::capture_message`, but these two were missed
- Added `tracing::warn!` and `sentry::capture_message` (Warning level) to both paths so future occurrences are diagnosable from logs and Sentry

## Test plan
- [x] `make quality` passes (fmt + lint + tests + Redis tests)
- [ ] Deploy to staging and trigger insufficient balance condition to confirm logs appear
- [ ] Verify Sentry receives the warning-level messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved runtime observability for wallet balance validation: now emits warning logs and records Sentry warnings with detailed Have vs Need information when ETH or USDC balances are insufficient. Functional behavior and error semantics remain unchanged; this change only increases diagnostic visibility for balance check failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->