### PR TITLE
Fix nonce race condition in fund_guest_wallet

### DIFF
--- a/src/services/wallet/manager.rs
+++ b/src/services/wallet/manager.rs
@@ -286,6 +286,18 @@ impl WalletManager {
         self.require_pool().instance_id()
     }
 
+    /// Acquire a distributed lock for a specific wallet address
+    ///
+    /// Unlike `acquire_specific_wallet`, this does not require the address
+    /// to be in the signers map. Useful for locking wallets that are managed
+    /// outside the pool (e.g., the funding wallet).
+    pub async fn acquire_lock(&self, address: &Address) -> Result<WalletLockGuard, String> {
+        let lock = self.create_lock(address);
+        let config = self.require_config();
+        lock.acquire(config.lock_retry_count, config.lock_retry_delay)
+            .await
+    }
+
     /// Create a lock for a specific wallet
     ///
     /// This is useful when you need to manage the lock separately from


### PR DESCRIPTION
## Summary
- The `fund_guest_wallet` endpoint was the only transaction-sending endpoint that bypassed the Redis-based distributed wallet locking, causing nonce collisions under concurrent requests
- Added `WalletManager::acquire_lock()` convenience method for locking wallets outside the pool (e.g., the funding wallet)
- The endpoint now acquires a Redis distributed lock before building the provider and sending ETH + USDC transfers, holding it for both transactions via RAII guard

## Test plan
- [x] `make quality` passes (fmt, lint, unit tests, Redis tests)
- [ ] Deploy to testnet and verify concurrent `fund_guest_wallet` requests no longer produce "nonce too low" errors
- [ ] Verify lock is released after successful and failed requests (RAII drop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented distributed locking on wallet funding to prevent nonce conflicts across concurrent requests and multiple server instances
  * Added error handling for temporary lock acquisition failures with improved messaging when funding is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->