### PR TITLE
Remove startingSqrtPriceX96 from CreatePerpParams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,11 +180,6 @@ pub async fn create_rocket() -> Rocket<Build> {
     )
     .expect("Failed to parse SQRT_PRICE_IMPACT_LIMIT_MODULE_ADDRESS");
 
-    // Optional default starting price
-    let default_starting_sqrt_price_x96 = env::var("PERP_DEFAULT_STARTING_SQRT_PRICE_X96")
-        .ok()
-        .and_then(|s| s.parse::<u128>().ok());
-
     // Log loaded module addresses for debugging
     tracing::info!("Perp module addresses loaded:");
     tracing::info!("  - Fees module: {:?}", fees_module_address);
@@ -200,9 +195,6 @@ pub async fn create_rocket() -> Rocket<Build> {
         "  - Price impact limit module: {:?}",
         sqrt_price_impact_limit_module_address
     );
-    if let Some(price) = default_starting_sqrt_price_x96 {
-        tracing::info!("  - Default starting sqrt price X96: {}", price);
-    }
 
     // Get environment configuration and chain ID
     let env_type = &rpc_config.env_type;
@@ -444,7 +436,6 @@ pub async fn create_rocket() -> Rocket<Build> {
         margin_ratios_module_address,
         lockup_period_module_address,
         sqrt_price_impact_limit_module_address,
-        default_starting_sqrt_price_x96,
         multicall3_address,
     };
 

--- a/src/models/app_state.rs
+++ b/src/models/app_state.rs
@@ -250,7 +250,6 @@ pub struct AppState {
     pub margin_ratios_module_address: Address,
     pub lockup_period_module_address: Address,
     pub sqrt_price_impact_limit_module_address: Address,
-    pub default_starting_sqrt_price_x96: Option<u128>,
 
     // Optional multicall3 contract for batch operations
     pub multicall3_address: Option<Address>,

--- a/src/models/requests.rs
+++ b/src/models/requests.rs
@@ -129,9 +129,6 @@ pub struct DeployPerpForBeaconRequest {
     pub lockup_period_module: String,
     /// Address of the sqrt price impact limit configuration module
     pub sqrt_price_impact_limit_module: String,
-    /// Starting sqrt price in Q96 format as string
-    #[schemars(with = "String")]
-    pub starting_sqrt_price_x96: String,
 }
 
 /// Batch deploy perpetual contracts for multiple beacons
@@ -147,9 +144,6 @@ pub struct BatchDeployPerpsForBeaconsRequest {
     pub lockup_period_module: String,
     /// Address of the sqrt price impact limit configuration module
     pub sqrt_price_impact_limit_module: String,
-    /// Starting sqrt price in Q96 format as string
-    #[schemars(with = "String")]
-    pub starting_sqrt_price_x96: String,
 }
 
 /// Deposit liquidity for a perpetual contract

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -104,7 +104,6 @@ sol! {
             IMarginRatios marginRatios;
             ILockupPeriod lockupPeriod;
             ISqrtPriceImpactLimit sqrtPriceImpactLimit;
-            uint160 startingSqrtPriceX96;
         }
 
         function createPerp(CreatePerpParams memory params) external returns (bytes32 perpId);

--- a/src/routes/perp.rs
+++ b/src/routes/perp.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, FixedBytes, U160};
+use alloy::primitives::{Address, FixedBytes};
 use rocket::serde::json::Json;
 use rocket::{State, http::Status, post};
 use rocket_okapi::openapi;
@@ -149,20 +149,6 @@ pub async fn deploy_perp_for_beacon_endpoint(
 
     tracing::info!("All module addresses validated successfully");
 
-    // Parse starting sqrt price
-    let starting_sqrt_price_x96 = match U160::from_str(&request.starting_sqrt_price_x96) {
-        Ok(price) => price,
-        Err(e) => {
-            let error_msg = format!(
-                "Invalid starting sqrt price X96 '{}': {}",
-                request.starting_sqrt_price_x96, e
-            );
-            tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
-            return Err(Status::BadRequest);
-        }
-    };
-
     tracing::info!("Starting perp deployment process...");
     match deploy_perp_for_beacon(
         state,
@@ -171,7 +157,6 @@ pub async fn deploy_perp_for_beacon_endpoint(
         margin_ratios_module,
         lockup_period_module,
         sqrt_price_impact_limit_module,
-        starting_sqrt_price_x96,
     )
     .await
     {

--- a/src/services/perp/core.rs
+++ b/src/services/perp/core.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, FixedBytes, Signed, U160, U256, Uint};
+use alloy::primitives::{Address, FixedBytes, Signed, U256, Uint};
 use alloy::providers::Provider;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -23,7 +23,6 @@ pub async fn deploy_perp_for_beacon(
     margin_ratios_module: Address,
     lockup_period_module: Address,
     sqrt_price_impact_limit_module: Address,
-    starting_sqrt_price_x96: U160,
 ) -> Result<DeployPerpForBeaconResponse, String> {
     tracing::info!("Starting perp deployment for beacon: {}", beacon_address);
 
@@ -55,8 +54,6 @@ pub async fn deploy_perp_for_beacon(
         "  - Sqrt price impact limit module: {}",
         sqrt_price_impact_limit_module
     );
-    tracing::info!("  - Starting sqrt price X96: {}", starting_sqrt_price_x96);
-
     // Check wallet balance first using read provider
     match state.read_provider.get_balance(wallet_address).await {
         Ok(balance) => {
@@ -153,7 +150,7 @@ pub async fn deploy_perp_for_beacon(
     }
 
     // Prepare the CreatePerpParams struct with modular configuration
-    tracing::info!("CreatePerpParams parameters (6 fields - modular architecture):");
+    tracing::info!("CreatePerpParams parameters (5 fields - modular architecture):");
     tracing::info!("  1. beacon: {} (address)", beacon_address);
     tracing::info!("  2. fees: {} (IFees module)", fees_module);
     tracing::info!(
@@ -168,10 +165,6 @@ pub async fn deploy_perp_for_beacon(
         "  5. sqrtPriceImpactLimit: {} (ISqrtPriceImpactLimit module)",
         sqrt_price_impact_limit_module
     );
-    tracing::info!(
-        "  6. startingSqrtPriceX96: {} (uint160)",
-        starting_sqrt_price_x96
-    );
 
     let create_perp_params = IPerpManager::CreatePerpParams {
         beacon: beacon_address,
@@ -179,7 +172,6 @@ pub async fn deploy_perp_for_beacon(
         marginRatios: margin_ratios_module,
         lockupPeriod: lockup_period_module,
         sqrtPriceImpactLimit: sqrt_price_impact_limit_module,
-        startingSqrtPriceX96: starting_sqrt_price_x96,
     };
 
     tracing::info!("CreatePerpParams struct prepared successfully");
@@ -244,7 +236,6 @@ pub async fn deploy_perp_for_beacon(
                         "  - Sqrt price impact limit module: {}",
                         sqrt_price_impact_limit_module
                     );
-                    tracing::error!("  - Starting sqrt price X96: {}", starting_sqrt_price_x96);
                 }
                 "Insufficient Funds" => {
                     tracing::error!("Troubleshooting hints:");

--- a/tests/integration_tests/perp_integration_tests.rs
+++ b/tests/integration_tests/perp_integration_tests.rs
@@ -103,7 +103,6 @@ async fn test_deploy_perp_invalid_beacon_address() {
         margin_ratios_module: "0x2222222222222222222222222222222222222222".to_string(),
         lockup_period_module: "0x3333333333333333333333333333333333333333".to_string(),
         sqrt_price_impact_limit_module: "0x4444444444444444444444444444444444444444".to_string(),
-        starting_sqrt_price_x96: "560227709747861419891227623424".to_string(), // sqrt(50) * 2^96
     });
 
     let result = deploy_perp_for_beacon_endpoint(request, token, state).await;
@@ -125,7 +124,6 @@ async fn test_deploy_perp_short_beacon_address() {
         margin_ratios_module: "0x2222222222222222222222222222222222222222".to_string(),
         lockup_period_module: "0x3333333333333333333333333333333333333333".to_string(),
         sqrt_price_impact_limit_module: "0x4444444444444444444444444444444444444444".to_string(),
-        starting_sqrt_price_x96: "560227709747861419891227623424".to_string(), // sqrt(50) * 2^96
     });
 
     let result = deploy_perp_for_beacon_endpoint(request, token, state).await;

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -594,7 +594,7 @@ pub async fn create_test_app_state() -> AppState {
             "0x7890123456789012345678901234567890123456",
         )
         .unwrap(),
-        default_starting_sqrt_price_x96: Some(560227709747861419891227623424), // sqrt(50) * 2^96
+
         multicall3_address: Some(
             Address::from_str("0xcA11bde05977b3631167028862bE2a173976CA11").unwrap(),
         ), // Standard multicall3 address for tests
@@ -662,7 +662,7 @@ pub async fn create_isolated_test_app_state() -> (AppState, AnvilManager) {
             "0x7890123456789012345678901234567890123456",
         )
         .unwrap(),
-        default_starting_sqrt_price_x96: Some(560227709747861419891227623424), // sqrt(50) * 2^96
+
         multicall3_address: Some(
             Address::from_str("0xcA11bde05977b3631167028862bE2a173976CA11").unwrap(),
         ), // Standard multicall3 address for tests
@@ -755,7 +755,6 @@ pub async fn create_isolated_test_app_state_with_redis() -> (AppState, AnvilMana
             "0x7890123456789012345678901234567890123456",
         )
         .unwrap(),
-        default_starting_sqrt_price_x96: Some(560227709747861419891227623424),
         multicall3_address: Some(
             Address::from_str("0xcA11bde05977b3631167028862bE2a173976CA11").unwrap(),
         ),
@@ -816,7 +815,7 @@ pub async fn create_test_app_state_with_account(account_index: usize) -> AppStat
             "0x7890123456789012345678901234567890123456",
         )
         .unwrap(),
-        default_starting_sqrt_price_x96: Some(560227709747861419891227623424), // sqrt(50) * 2^96
+
         multicall3_address: Some(
             Address::from_str("0xcA11bde05977b3631167028862bE2a173976CA11").unwrap(),
         ), // Standard multicall3 address for tests
@@ -929,7 +928,7 @@ pub async fn create_simple_test_app_state() -> AppState {
             "0x7890123456789012345678901234567890123456",
         )
         .unwrap(),
-        default_starting_sqrt_price_x96: Some(560227709747861419891227623424), // sqrt(50) * 2^96
+
         multicall3_address: Some(
             Address::from_str("0xcA11bde05977b3631167028862bE2a173976CA11").unwrap(),
         ), // Standard multicall3 address for tests
@@ -991,7 +990,7 @@ pub async fn create_test_app_state_with_provider(
             "0x7890123456789012345678901234567890123456",
         )
         .unwrap(),
-        default_starting_sqrt_price_x96: Some(560227709747861419891227623424), // sqrt(50) * 2^96
+
         multicall3_address: Some(
             Address::from_str("0xcA11bde05977b3631167028862bE2a173976CA11").unwrap(),
         ), // Standard multicall3 address for tests


### PR DESCRIPTION
## Summary
- Removes `startingSqrtPriceX96` from `CreatePerpParams` to match the deployed PerpManager contract (v0.0.1)
- The deployed contract derives the starting price on-chain from `IBeacon(beacon).index()` inside `PerpLogic.createPerp()`, so this field should not be in the ABI
- Removes the field from API request models, route handler, service function, AppState, and env var loading

## Test plan
- [x] `make quality` passes (fmt + lint + unit tests + Redis tests)
- [x] Verified deployed contract struct at `perpcity-contracts` v0.0.1 tag has 5 fields (no `startingSqrtPriceX96`)
- [x] Kept `StartingSqrtPriceTooLow`/`StartingSqrtPriceTooHigh` revert decoders since the contract still emits these errors on-chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed starting sqrt price parameter from perpetual market deployment configurations, altering the structure of deployment requests and initialization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->