### PR TITLE
Fix Sentry ScopeGuard panic in async handlers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,10 @@ async fn rocket() -> _ {
                 location.column()
             );
         }
-        sentry::capture_message(&format!("Panic: {panic_info:?}"), sentry::Level::Fatal);
+        let msg = format!("Panic: {panic_info:?}");
+        let _ = std::panic::catch_unwind(|| {
+            sentry::capture_message(&msg, sentry::Level::Fatal);
+        });
     }));
 
     create_rocket().await

--- a/src/routes/beacon.rs
+++ b/src/routes/beacon.rs
@@ -44,8 +44,8 @@ pub async fn create_beacon(
         "Received request: POST /create_beacon (type={})",
         request.beacon_type
     );
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/create_beacon");
         scope.set_extra("beacon_type", request.beacon_type.clone().into());
     });
@@ -89,7 +89,7 @@ pub async fn create_beacon(
                 config.slug,
                 response.beacon_address
             );
-            sentry::capture_message(
+            hub.capture_message(
                 &format!(
                     "Beacon created: {} (type={})",
                     response.beacon_address, config.slug
@@ -104,7 +104,7 @@ pub async fn create_beacon(
         }
         Err(e) => {
             tracing::error!("Failed to create '{}' beacon: {}", config.slug, e);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Failed to create beacon (type={}): {e}", config.slug),
                 sentry::Level::Error,
             );
@@ -128,8 +128,8 @@ pub async fn create_beacon_with_ecdsa(
         "Received request: POST /create_beacon_with_ecdsa (initial_index={})",
         request.initial_index
     );
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/create_beacon_with_ecdsa");
         scope.set_extra("initial_index", request.initial_index.to_string().into());
     });
@@ -141,7 +141,7 @@ pub async fn create_beacon_with_ecdsa(
             Err(e) => {
                 let error_msg = format!("ECDSA beacon creation failed: {e}");
                 tracing::error!("{}", error_msg);
-                sentry::capture_message(&error_msg, sentry::Level::Error);
+                hub.capture_message(&error_msg, sentry::Level::Error);
                 return Ok(Json(ApiResponse {
                     success: false,
                     data: None,
@@ -179,7 +179,7 @@ pub async fn create_beacon_with_ecdsa(
         Err(e) => {
             let warn_msg = format!("Beacon {beacon_address} created but registration failed: {e}");
             tracing::warn!("{}", warn_msg);
-            sentry::capture_message(&warn_msg, sentry::Level::Warning);
+            hub.capture_message(&warn_msg, sentry::Level::Warning);
             (false, None)
         }
     };
@@ -199,7 +199,7 @@ pub async fn create_beacon_with_ecdsa(
         registered,
     );
 
-    sentry::capture_message(
+    hub.capture_message(
         &format!(
             "ECDSA beacon created: {} with verifier {}",
             response.beacon_address, response.verifier_address
@@ -225,8 +225,8 @@ pub async fn register_beacon(
     state: &State<AppState>,
 ) -> Result<Json<ApiResponse<String>>, Status> {
     tracing::info!("Received request: POST /register_beacon");
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/register_beacon");
         scope.set_extra("beacon_address", request.beacon_address.clone().into());
         scope.set_extra("registry_address", request.registry_address.clone().into());
@@ -239,7 +239,7 @@ pub async fn register_beacon(
             request.beacon_address
         );
         tracing::error!("{}", error_msg);
-        sentry::capture_message(&error_msg, sentry::Level::Error);
+        hub.capture_message(&error_msg, sentry::Level::Error);
         return Err(Status::BadRequest);
     }
 
@@ -249,7 +249,7 @@ pub async fn register_beacon(
         Err(e) => {
             let error_msg = format!("Invalid beacon address '{}': {}", request.beacon_address, e);
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -261,7 +261,7 @@ pub async fn register_beacon(
             request.registry_address
         );
         tracing::error!("{}", error_msg);
-        sentry::capture_message(&error_msg, sentry::Level::Error);
+        hub.capture_message(&error_msg, sentry::Level::Error);
         return Err(Status::BadRequest);
     }
 
@@ -274,7 +274,7 @@ pub async fn register_beacon(
                 request.registry_address, e
             );
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -302,7 +302,7 @@ pub async fn register_beacon(
                 beacon_address,
                 registry_address
             );
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Beacon registered: {beacon_address} at registry {registry_address}"),
                 sentry::Level::Info,
             );
@@ -315,7 +315,7 @@ pub async fn register_beacon(
         Err(e) => {
             let error_msg = format!("Failed to register beacon {beacon_address}: {e}");
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             Err(Status::InternalServerError)
         }
     }
@@ -333,8 +333,8 @@ pub async fn update_beacon(
     state: &State<AppState>,
 ) -> Result<Json<ApiResponse<String>>, Status> {
     tracing::info!("Received request: POST /update_beacon");
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/update_beacon");
         scope.set_extra("beacon_address", request.beacon_address.clone().into());
         scope.set_extra("proof_length", request.proof.len().into());
@@ -344,7 +344,7 @@ pub async fn update_beacon(
     match service_update_beacon(state.inner(), request.into_inner()).await {
         Ok(tx_hash) => {
             tracing::info!("Successfully updated beacon. TX: {:?}", tx_hash);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Beacon updated successfully. TX: {tx_hash:?}"),
                 sentry::Level::Info,
             );
@@ -356,7 +356,7 @@ pub async fn update_beacon(
         }
         Err(e) => {
             tracing::error!("Failed to update beacon: {}", e);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Failed to update beacon: {e}"),
                 sentry::Level::Error,
             );
@@ -377,8 +377,8 @@ pub async fn batch_update_beacon(
     state: &State<AppState>,
 ) -> Result<Json<ApiResponse<BatchUpdateBeaconResponse>>, Status> {
     tracing::info!("Received request: POST /batch_update_beacon");
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/batch_update_beacon");
         scope.set_extra("update_count", request.updates.len().into());
     });
@@ -428,8 +428,8 @@ pub async fn update_beacon_with_ecdsa_adapter(
     state: &State<AppState>,
 ) -> Result<Json<ApiResponse<String>>, Status> {
     tracing::info!("Received request: POST /update_beacon_with_ecdsa_adapter");
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/update_beacon_with_ecdsa_adapter");
         scope.set_extra("beacon_address", request.beacon_address.clone().into());
         scope.set_extra("measurement", request.measurement.clone().into());
@@ -441,7 +441,7 @@ pub async fn update_beacon_with_ecdsa_adapter(
                 "Successfully updated beacon with ECDSA signature. TX: {:?}",
                 tx_hash
             );
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Beacon updated with ECDSA signature. TX: {tx_hash:?}"),
                 sentry::Level::Info,
             );
@@ -453,7 +453,7 @@ pub async fn update_beacon_with_ecdsa_adapter(
         }
         Err(e) => {
             tracing::error!("Failed to update beacon with ECDSA signature: {}", e);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Failed to update beacon with ECDSA signature: {e}"),
                 sentry::Level::Error,
             );
@@ -477,8 +477,8 @@ pub async fn create_lbcgbm_beacon_endpoint(
         "Received request: POST /create_lbcgbm_beacon (initial_index={})",
         request.initial_index
     );
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/create_lbcgbm_beacon");
     });
 
@@ -520,7 +520,7 @@ pub async fn create_lbcgbm_beacon_endpoint(
         Err(e) => {
             let error_msg = format!("LBCGBM beacon creation failed: {e}");
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Ok(Json(ApiResponse {
                 success: false,
                 data: None,
@@ -561,7 +561,7 @@ pub async fn create_lbcgbm_beacon_endpoint(
             let warn_msg =
                 format!("LBCGBM beacon {beacon_address:#x} created but registration failed: {e}");
             tracing::warn!("{}", warn_msg);
-            sentry::capture_message(&warn_msg, sentry::Level::Warning);
+            hub.capture_message(&warn_msg, sentry::Level::Warning);
             (false, None)
         }
     };
@@ -611,8 +611,8 @@ pub async fn create_weighted_sum_composite_beacon_endpoint(
         "Received request: POST /create_weighted_sum_composite_beacon ({} reference beacons)",
         request.reference_beacons.len()
     );
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/create_weighted_sum_composite_beacon");
     });
 
@@ -631,7 +631,7 @@ pub async fn create_weighted_sum_composite_beacon_endpoint(
         Ok(Some(_)) => {
             let msg = "WeightedSumComposite beacon type is disabled or misconfigured";
             tracing::warn!("{}", msg);
-            sentry::capture_message(msg, sentry::Level::Warning);
+            hub.capture_message(msg, sentry::Level::Warning);
             return Ok(Json(ApiResponse {
                 success: false,
                 data: None,
@@ -641,7 +641,7 @@ pub async fn create_weighted_sum_composite_beacon_endpoint(
         Ok(None) => {
             let msg = "WeightedSumComposite beacon type not registered. Set WEIGHTED_SUM_COMPOSITE_FACTORY_ADDRESS env var.";
             tracing::warn!("{}", msg);
-            sentry::capture_message(msg, sentry::Level::Warning);
+            hub.capture_message(msg, sentry::Level::Warning);
             return Ok(Json(ApiResponse {
                 success: false,
                 data: None,
@@ -651,7 +651,7 @@ pub async fn create_weighted_sum_composite_beacon_endpoint(
         Err(e) => {
             let msg = format!("Failed to look up WeightedSumComposite beacon type: {e}");
             tracing::error!("{}", msg);
-            sentry::capture_message(&msg, sentry::Level::Error);
+            hub.capture_message(&msg, sentry::Level::Error);
             return Ok(Json(ApiResponse {
                 success: false,
                 data: None,
@@ -667,7 +667,7 @@ pub async fn create_weighted_sum_composite_beacon_endpoint(
             Err(e) => {
                 let error_msg = format!("WeightedSumComposite beacon creation failed: {e}");
                 tracing::error!("{}", error_msg);
-                sentry::capture_message(&error_msg, sentry::Level::Error);
+                hub.capture_message(&error_msg, sentry::Level::Error);
                 return Ok(Json(ApiResponse {
                     success: false,
                     data: None,
@@ -695,7 +695,7 @@ pub async fn create_weighted_sum_composite_beacon_endpoint(
                 "WeightedSumComposite beacon {beacon_address:#x} created but registration failed: {e}"
             );
             tracing::warn!("{}", warn_msg);
-            sentry::capture_message(&warn_msg, sentry::Level::Warning);
+            hub.capture_message(&warn_msg, sentry::Level::Warning);
             Ok(Json(ApiResponse {
                 success: true,
                 data: Some(CreateBeaconResponse {
@@ -726,8 +726,8 @@ pub async fn create_modular_beacon(
         "Received request: POST /create_modular_beacon (recipe={})",
         request.recipe
     );
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/create_modular_beacon");
         scope.set_extra("recipe", request.recipe.clone().into());
     });
@@ -746,7 +746,7 @@ pub async fn create_modular_beacon(
         }
         Err(e) => {
             tracing::error!("Failed to look up recipe: {}", e);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Failed to look up recipe '{}': {e}", request.recipe),
                 sentry::Level::Error,
             );
@@ -772,7 +772,7 @@ pub async fn create_modular_beacon(
                 recipe.slug
             );
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Ok(Json(ApiResponse {
                 success: false,
                 data: None,
@@ -813,7 +813,7 @@ pub async fn create_modular_beacon(
             let warn_msg =
                 format!("Modular beacon {beacon_address:#x} created but registration failed: {e}");
             tracing::warn!("{}", warn_msg);
-            sentry::capture_message(&warn_msg, sentry::Level::Warning);
+            hub.capture_message(&warn_msg, sentry::Level::Warning);
             (false, None)
         }
     };
@@ -834,7 +834,7 @@ pub async fn create_modular_beacon(
         registered,
     );
 
-    sentry::capture_message(
+    hub.capture_message(
         &format!(
             "Modular beacon created: {} (recipe={})",
             response.beacon_address, recipe.slug

--- a/src/routes/perp.rs
+++ b/src/routes/perp.rs
@@ -28,8 +28,8 @@ pub async fn deploy_perp_for_beacon_endpoint(
     tracing::info!("Received request: POST /deploy_perp_for_beacon");
     tracing::info!("Requested beacon address: {}", request.beacon_address);
 
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/deploy_perp_for_beacon");
         scope.set_extra("beacon_address", request.beacon_address.clone().into());
         scope.set_extra(
@@ -45,7 +45,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
         Err(e) => {
             let error_msg = format!("Invalid beacon address '{}': {}", request.beacon_address, e);
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -59,7 +59,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
                 request.fees_module, e
             );
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -72,7 +72,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
                 request.margin_ratios_module, e
             );
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -85,7 +85,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
                 request.lockup_period_module, e
             );
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -99,7 +99,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
                     request.sqrt_price_impact_limit_module, e
                 );
                 tracing::error!("{}", error_msg);
-                sentry::capture_message(&error_msg, sentry::Level::Error);
+                hub.capture_message(&error_msg, sentry::Level::Error);
                 return Err(Status::BadRequest);
             }
         };
@@ -110,7 +110,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
     if let Err(e) =
         validate_module_address(&state.provider.read_provider, fees_module, "Fees module").await
     {
-        sentry::capture_message(&e, sentry::Level::Error);
+        hub.capture_message(&e, sentry::Level::Error);
         return Err(Status::BadRequest);
     }
 
@@ -121,7 +121,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
     )
     .await
     {
-        sentry::capture_message(&e, sentry::Level::Error);
+        hub.capture_message(&e, sentry::Level::Error);
         return Err(Status::BadRequest);
     }
 
@@ -132,7 +132,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
     )
     .await
     {
-        sentry::capture_message(&e, sentry::Level::Error);
+        hub.capture_message(&e, sentry::Level::Error);
         return Err(Status::BadRequest);
     }
 
@@ -143,7 +143,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
     )
     .await
     {
-        sentry::capture_message(&e, sentry::Level::Error);
+        hub.capture_message(&e, sentry::Level::Error);
         return Err(Status::BadRequest);
     }
 
@@ -166,7 +166,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
             tracing::info!("Perp ID: {}", response.perp_id);
             tracing::info!("PerpManager address: {}", response.perp_manager_address);
             tracing::info!("Transaction hash: {}", response.transaction_hash);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!(
                     "Perp deployed successfully for beacon {beacon_address}, perp ID: {}",
                     response.perp_id
@@ -212,7 +212,7 @@ pub async fn deploy_perp_for_beacon_endpoint(
                 tracing::error!("  3. Try the request again after a short delay");
             }
 
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             Err(Status::InternalServerError)
         }
     }
@@ -230,8 +230,8 @@ pub async fn deposit_liquidity_for_perp_endpoint(
     state: &State<AppState>,
 ) -> Result<Json<ApiResponse<DepositLiquidityForPerpResponse>>, Status> {
     tracing::info!("Received request: POST /deposit_liquidity_for_perp");
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/deposit_liquidity_for_perp");
         scope.set_extra("perp_id", request.perp_id.clone().into());
         scope.set_extra("margin_amount", request.margin_amount_usdc.clone().into());
@@ -243,7 +243,7 @@ pub async fn deposit_liquidity_for_perp_endpoint(
         Err(e) => {
             let error_msg = format!("Invalid perp ID '{}': {e}", request.perp_id);
             tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -259,7 +259,7 @@ pub async fn deposit_liquidity_for_perp_endpoint(
             tracing::error!("{}", error_msg);
             tracing::error!("Margin amount must be a valid number in USDC with 6 decimals");
             tracing::error!("  Examples: '1000000' = 1 USDC, '500000000' = 500 USDC");
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             return Err(Status::BadRequest);
         }
     };
@@ -335,7 +335,7 @@ pub async fn deposit_liquidity_for_perp_endpoint(
                 tracing::error!("  3. Try the request again after a short delay");
             }
 
-            sentry::capture_message(&error_msg, sentry::Level::Error);
+            hub.capture_message(&error_msg, sentry::Level::Error);
             Err(Status::InternalServerError)
         }
     }

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -24,8 +24,8 @@ pub async fn fund_guest_wallet(
     _token: ApiToken,
 ) -> Result<Json<ApiResponse<String>>, (Status, Json<ApiResponse<String>>)> {
     tracing::info!("Received request: POST /fund_guest_wallet");
-    let _guard = sentry::Hub::current().push_scope();
-    sentry::configure_scope(|scope| {
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.configure_scope(|scope| {
         scope.set_tag("endpoint", "/fund_guest_wallet");
         scope.set_extra("wallet_address", request.wallet_address.clone().into());
         scope.set_extra("usdc_amount", request.usdc_amount.clone().into());
@@ -124,7 +124,7 @@ pub async fn fund_guest_wallet(
         Ok(balance) => balance,
         Err(e) => {
             tracing::error!("Failed to get ETH balance: {}", e);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Failed to get ETH balance: {e}"),
                 sentry::Level::Error,
             );
@@ -147,7 +147,7 @@ pub async fn fund_guest_wallet(
             alloy::primitives::utils::format_ether(eth_balance),
             alloy::primitives::utils::format_ether(U256::from(eth_amount))
         );
-        sentry::capture_message(
+        hub.capture_message(
             &format!(
                 "Insufficient ETH balance in funding wallet. Have: {} ETH, Need: {} ETH",
                 alloy::primitives::utils::format_ether(eth_balance),
@@ -179,7 +179,7 @@ pub async fn fund_guest_wallet(
         Ok(result) => result,
         Err(e) => {
             tracing::error!("Failed to get USDC balance: {}", e);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Failed to get USDC balance: {e}"),
                 sentry::Level::Error,
             );
@@ -202,7 +202,7 @@ pub async fn fund_guest_wallet(
             usdc_balance / U256::from(1_000_000),
             usdc_amount / 1_000_000
         );
-        sentry::capture_message(
+        hub.capture_message(
             &format!(
                 "Insufficient USDC balance in funding wallet. Have: {} USDC, Need: {} USDC",
                 usdc_balance / U256::from(1_000_000),
@@ -233,7 +233,7 @@ pub async fn fund_guest_wallet(
         .await
         .map_err(|e| {
             tracing::error!("Failed to acquire funding wallet lock: {}", e);
-            sentry::capture_message(
+            hub.capture_message(
                 &format!("Failed to acquire funding wallet lock: {e}"),
                 sentry::Level::Error,
             );
@@ -267,7 +267,7 @@ pub async fn fund_guest_wallet(
             Ok(receipt) => receipt.transaction_hash,
             Err(e) => {
                 tracing::error!("Failed to get ETH transaction receipt: {}", e);
-                sentry::capture_message(
+                hub.capture_message(
                     &format!("Failed to get ETH transaction receipt: {e}"),
                     sentry::Level::Error,
                 );
@@ -283,7 +283,7 @@ pub async fn fund_guest_wallet(
         },
         Err(e) => {
             tracing::error!("Failed to send ETH: {}", e);
-            sentry::capture_message(&format!("Failed to send ETH: {e}"), sentry::Level::Error);
+            hub.capture_message(&format!("Failed to send ETH: {e}"), sentry::Level::Error);
             return Err((
                 Status::InternalServerError,
                 Json(ApiResponse {
@@ -308,7 +308,7 @@ pub async fn fund_guest_wallet(
             Ok(receipt) => receipt,
             Err(e) => {
                 tracing::error!("Failed to get USDC transaction receipt: {}", e);
-                sentry::capture_message(
+                hub.capture_message(
                     &format!("Failed to get USDC transaction receipt: {e}"),
                     sentry::Level::Error,
                 );
@@ -324,7 +324,7 @@ pub async fn fund_guest_wallet(
         },
         Err(e) => {
             tracing::error!("Failed to send USDC: {}", e);
-            sentry::capture_message(&format!("Failed to send USDC: {e}"), sentry::Level::Error);
+            hub.capture_message(&format!("Failed to send USDC: {e}"), sentry::Level::Error);
             return Err((
                 Status::InternalServerError,
                 Json(ApiResponse {


### PR DESCRIPTION
## Summary

- **Fixes production panic** in `fund_guest_wallet` (and prevents the same panic in all 11 other async handlers) caused by holding a Sentry `ScopeGuard` across `.await` points. Tokio migrates tasks between OS threads, corrupting the thread-local scope stack depth and triggering a panic in `sentry-core::scope::real.rs:147`.
- Replaces `Hub::current().push_scope()` (thread-local) with `Hub::new_from_top(Hub::main())` (per-request isolated hub) across all 12 async route handlers in `wallet.rs`, `perp.rs`, and `beacon.rs`. All `sentry::capture_message` calls within those handlers now use the per-request hub directly.
- Wraps `sentry::capture_message` in the panic hook (`main.rs`) with `catch_unwind` to prevent double-panic when the panic originates inside Sentry itself.

## Production error

```
USDC transfer hash: 0xd9690b4c02d09...
PANIC occurred: PanicHookInfo { ... location: "sentry-core-0.32.3/src/scope/real.rs:147:17" ... }
Handler fund_guest_wallet panicked.
Response: POST /fund_guest_wallet - Status: 500 Internal Server Error
```

## Test plan

- [x] `cargo +nightly fmt -- --check` passes
- [x] `cargo +nightly clippy --all --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo check` compiles successfully
- [ ] CI runs (format, lint, unit-tests, integration-tests, wallet-tests, full-integration-tests, docker) all pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error tracking resilience to prevent unexpected failures during event logging.

* **Refactor**
  * Improved error reporting consistency across application endpoints for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->