### PR TITLE
fix: Hardcode index_scale as Q96 for group transforms

### DIFF
--- a/src/models/requests.rs
+++ b/src/models/requests.rs
@@ -370,7 +370,4 @@ pub struct ModularBeaconParams {
     /// Initial slow EMA for RelativeDominance
     #[schemars(with = "Option<Vec<String>>")]
     pub initial_m_slow: Option<Vec<u128>>,
-    /// Index scale for group transforms (WAD-scaled)
-    #[schemars(with = "Option<String>")]
-    pub index_scale: Option<u128>,
 }

--- a/src/services/beacon/modular.rs
+++ b/src/services/beacon/modular.rs
@@ -1129,7 +1129,7 @@ async fn create_group_transform(
     let addr = match spec {
         GroupTransformSpec::Softmax => {
             let steepness = U256::from(require_param(&params.steepness, "steepness")?);
-            let index_scale = U256::from(require_param(&params.index_scale, "index_scale")?);
+            let index_scale = Q96;
 
             tracing::info!("Creating Softmax group transform");
             let factory = ISoftmaxFactory::new(factory_addr, provider);
@@ -1159,7 +1159,7 @@ async fn create_group_transform(
             addr
         }
         GroupTransformSpec::GMNormalize => {
-            let index_scale = U256::from(require_param(&params.index_scale, "index_scale")?);
+            let index_scale = Q96;
 
             tracing::info!("Creating GMNormalize group transform");
             let factory = IGMNormalizeFactory::new(factory_addr, provider);

--- a/tests/unit_tests/modular_beacon_tests.rs
+++ b/tests/unit_tests/modular_beacon_tests.rs
@@ -108,7 +108,6 @@ fn test_modular_beacon_params_all_none_serialization() {
     assert!(deserialized.decay_slow.is_none());
     assert!(deserialized.initial_m_fast.is_none());
     assert!(deserialized.initial_m_slow.is_none());
-    assert!(deserialized.index_scale.is_none());
 
     // All null values in JSON
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -160,7 +159,6 @@ fn test_modular_beacon_params_standalone_cgbm_fields() {
     // Group fields remain None
     assert!(deserialized.num_classes.is_none());
     assert!(deserialized.initial_indices.is_none());
-    assert!(deserialized.index_scale.is_none());
 }
 
 #[test]
@@ -180,7 +178,6 @@ fn test_modular_beacon_params_group_fields() {
             1_000_000_000_000_000_000,
             1_000_000_000_000_000_000,
         ]),
-        index_scale: Some(1_000_000_000_000_000_000),
         ..Default::default()
     };
 
@@ -196,7 +193,6 @@ fn test_modular_beacon_params_group_fields() {
     assert_eq!(deserialized.alpha, Some(500_000_000_000_000_000));
     assert_eq!(deserialized.decay, Some(950_000_000_000_000_000));
     assert_eq!(deserialized.initial_ema.as_ref().unwrap().len(), 3);
-    assert_eq!(deserialized.index_scale, Some(1_000_000_000_000_000_000));
     // Standalone fields remain None
     assert!(deserialized.sigma_base.is_none());
     assert!(deserialized.scaling_factor.is_none());


### PR DESCRIPTION
index_scale is always 2^96 (Q96 fixed-point) — no need to accept it as a user-supplied parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an optional per-request scaling parameter for modular beacon creation. Beacon transformations now use a single, standardized scaling value across simulated and real operations for consistent behavior and predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->