### PR TITLE
Optimize RPC usage to stay within Alchemy free tier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,24 +47,10 @@ pub type AlloyProvider = alloy::providers::fillers::FillProvider<
     alloy::network::Ethereum,
 >;
 
-// Read-only provider type without wallet (for queries only, cannot sign transactions)
-pub type ReadOnlyProvider = alloy::providers::fillers::FillProvider<
-    alloy::providers::fillers::JoinFill<
-        alloy::providers::Identity,
-        alloy::providers::fillers::JoinFill<
-            alloy::providers::fillers::GasFiller,
-            alloy::providers::fillers::JoinFill<
-                alloy::providers::fillers::BlobGasFiller,
-                alloy::providers::fillers::JoinFill<
-                    alloy::providers::fillers::NonceFiller,
-                    alloy::providers::fillers::ChainIdFiller,
-                >,
-            >,
-        >,
-    >,
-    alloy::providers::RootProvider<alloy::network::Ethereum>,
-    alloy::network::Ethereum,
->;
+// Read-only provider type without wallet or fillers (for queries only).
+// Uses no fillers (Gas, Nonce, BlobGas, ChainId) since read operations
+// don't need them, saving unnecessary RPC calls.
+pub type ReadOnlyProvider = alloy::providers::RootProvider<alloy::network::Ethereum>;
 
 /// Serves the OpenAPI JSON specification at /openapi.json
 #[rocket::get("/openapi.json")]

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -266,22 +266,31 @@ pub async fn fund_guest_wallet(
         .value(U256::from(eth_amount));
 
     let eth_tx_hash = match funding_provider.send_transaction(tx_request).await {
-        Ok(pending) => match pending.get_receipt().await {
-            Ok(receipt) => receipt.transaction_hash,
-            Err(e) => {
-                let detailed_error = format!("Failed to get ETH transaction receipt: {e}");
-                tracing::error!("{}", detailed_error);
-                sentry_error(&hub, "TransactionError", detailed_error, vec![]);
-                return Err((
-                    Status::InternalServerError,
-                    Json(ApiResponse {
-                        success: false,
-                        data: None,
-                        message: "Failed to confirm ETH transaction".to_string(),
-                    }),
-                ));
+        Ok(pending) => {
+            let tx_hash = *pending.tx_hash();
+            match crate::services::transaction::poll_for_receipt(
+                &*state.provider.read_provider,
+                tx_hash,
+                60,
+            )
+            .await
+            {
+                Ok(receipt) => receipt.transaction_hash,
+                Err(e) => {
+                    let detailed_error = format!("Failed to get ETH transaction receipt: {e}");
+                    tracing::error!("{}", detailed_error);
+                    sentry_error(&hub, "TransactionError", detailed_error, vec![]);
+                    return Err((
+                        Status::InternalServerError,
+                        Json(ApiResponse {
+                            success: false,
+                            data: None,
+                            message: "Failed to confirm ETH transaction".to_string(),
+                        }),
+                    ));
+                }
             }
-        },
+        }
         Err(e) => {
             let detailed_error = format!("Failed to send ETH: {e}");
             tracing::error!("{}", detailed_error);
@@ -306,22 +315,31 @@ pub async fn fund_guest_wallet(
         .send()
         .await
     {
-        Ok(pending) => match pending.get_receipt().await {
-            Ok(receipt) => receipt,
-            Err(e) => {
-                let detailed_error = format!("Failed to get USDC transaction receipt: {e}");
-                tracing::error!("{}", detailed_error);
-                sentry_error(&hub, "TransactionError", detailed_error, vec![]);
-                return Err((
-                    Status::InternalServerError,
-                    Json(ApiResponse {
-                        success: false,
-                        data: None,
-                        message: "Failed to confirm USDC transaction".to_string(),
-                    }),
-                ));
+        Ok(pending) => {
+            let tx_hash = *pending.tx_hash();
+            match crate::services::transaction::poll_for_receipt(
+                &*state.provider.read_provider,
+                tx_hash,
+                60,
+            )
+            .await
+            {
+                Ok(receipt) => receipt,
+                Err(e) => {
+                    let detailed_error = format!("Failed to get USDC transaction receipt: {e}");
+                    tracing::error!("{}", detailed_error);
+                    sentry_error(&hub, "TransactionError", detailed_error, vec![]);
+                    return Err((
+                        Status::InternalServerError,
+                        Json(ApiResponse {
+                            success: false,
+                            data: None,
+                            message: "Failed to confirm USDC transaction".to_string(),
+                        }),
+                    ));
+                }
             }
-        },
+        }
         Err(e) => {
             let detailed_error = format!("Failed to send USDC: {e}");
             tracing::error!("{}", detailed_error);

--- a/src/services/beacon/batch.rs
+++ b/src/services/beacon/batch.rs
@@ -236,8 +236,15 @@ async fn batch_update_with_multicall3(
     // First send the transaction
     match multicall_contract.aggregate3(calls.clone()).send().await {
         Ok(pending_tx) => {
+            let tx_hash_raw = *pending_tx.tx_hash();
             tracing::info!("Multicall3 batch update transaction sent, waiting for receipt...");
-            match pending_tx.get_receipt().await {
+            match crate::services::transaction::poll_for_receipt(
+                &*state.provider.read_provider,
+                tx_hash_raw,
+                120,
+            )
+            .await
+            {
                 Ok(receipt) => {
                     tracing::info!(
                         "Multicall3 batch update confirmed: {:?}",

--- a/src/services/beacon/core.rs
+++ b/src/services/beacon/core.rs
@@ -1,7 +1,6 @@
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
-use std::{str::FromStr, time::Duration};
-use tokio::time::timeout;
+use std::str::FromStr;
 use tracing;
 
 use crate::models::beacon_type::{BeaconTypeConfig, FactoryType};
@@ -300,143 +299,18 @@ pub async fn register_beacon_with_registry(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Registration transaction hash: {:?}", tx_hash);
 
-    // Use get_receipt() with timeout and fallback to on-chain check
-    let receipt = match timeout(Duration::from_secs(60), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => {
-            tracing::info!("Registration confirmed via get_receipt()");
-            receipt
-        }
-        Ok(Err(e)) => {
-            tracing::warn!("get_receipt() failed for registration: {}", e);
-            tracing::info!("Falling back to on-chain registration check...");
-
-            tracing::info!("Checking registration transaction {} on-chain...", tx_hash);
-
-            // Try to get the receipt directly from the read provider with timeout
-            match timeout(
-                Duration::from_secs(30),
-                state
-                    .provider
-                    .read_provider
-                    .get_transaction_receipt(tx_hash),
-            )
-            .await
-            {
-                Ok(Ok(Some(receipt))) => {
-                    tracing::info!("Registration found on-chain via direct receipt lookup");
-                    receipt
-                }
-                Ok(Ok(None)) => {
-                    let error_msg = format!(
-                        "Registration transaction {tx_hash} not found on-chain after timeout"
-                    );
-                    tracing::error!("{}", error_msg);
-                    tracing::error!("This could indicate:");
-                    tracing::error!("  - Registration transaction was dropped/replaced");
-                    tracing::error!("  - Network issues prevented confirmation");
-                    tracing::error!("  - Registration is still pending");
-                    sentry::capture_message(&error_msg, sentry::Level::Error);
-                    return Err(error_msg);
-                }
-                Ok(Err(e)) => {
-                    let error_msg =
-                        format!("Failed to check registration transaction {tx_hash} on-chain: {e}");
-                    tracing::error!("{}", error_msg);
-                    tracing::error!("Original get_receipt() error: {}", e);
-                    sentry::capture_message(&error_msg, sentry::Level::Error);
-                    return Err(error_msg);
-                }
-                Err(_) => {
-                    let error_msg =
-                        format!("Timeout checking registration transaction {tx_hash} on-chain");
-                    tracing::error!("{}", error_msg);
-                    tracing::error!("Network may be slow or unresponsive");
-                    sentry::capture_message(&error_msg, sentry::Level::Error);
-                    return Err(error_msg);
-                }
-            }
-        }
-        Err(_) => {
-            tracing::warn!(
-                "Initial get_receipt() timed out for registration transaction, trying extended fallback..."
-            );
-            tracing::info!(
-                "Checking registration transaction {} on-chain with progressive timeouts...",
-                tx_hash
-            );
-
-            // Extended fallback: retry with progressive timeouts (15s, 30s, 60s) for Base network
-            let mut retry_count = 0;
-            let max_retries = 3;
-            let timeout_seconds = [15u64, 30u64, 60u64]; // Progressive timeout pattern
-
-            loop {
-                retry_count += 1;
-                let current_timeout = timeout_seconds[retry_count - 1];
-                tracing::info!(
-                    "Registration transaction receipt attempt {}/{} ({}s timeout)",
-                    retry_count,
-                    max_retries,
-                    current_timeout
-                );
-
-                match timeout(
-                    Duration::from_secs(current_timeout),
-                    is_transaction_confirmed(state, tx_hash),
-                )
-                .await
-                {
-                    Ok(Ok(Some(receipt))) => {
-                        tracing::info!(
-                            "Registration transaction found on-chain via extended fallback (attempt {})",
-                            retry_count
-                        );
-                        break receipt;
-                    }
-                    Ok(Ok(None)) => {
-                        if retry_count >= max_retries {
-                            let error_msg = format!(
-                                "Registration transaction {tx_hash} not found on-chain after {max_retries} attempts"
-                            );
-                            tracing::error!("{}", error_msg);
-                            tracing::error!("This could indicate:");
-                            tracing::error!("  - Registration transaction was dropped/replaced");
-                            tracing::error!("  - Network issues prevented confirmation");
-                            tracing::error!("  - Transaction is still pending (check gas price)");
-                            tracing::error!("  - Base network congestion causing delays");
-                            return Err(error_msg);
-                        }
-                        tracing::warn!(
-                            "Registration transaction not found on attempt {}, retrying...",
-                            retry_count
-                        );
-                        tokio::time::sleep(Duration::from_secs(3)).await; // Brief pause between retries
-                    }
-                    Ok(Err(e)) => {
-                        let error_msg = format!(
-                            "Failed to check registration transaction {tx_hash} on-chain: {e}"
-                        );
-                        tracing::error!("{}", error_msg);
-                        return Err(error_msg);
-                    }
-                    Err(_) => {
-                        if retry_count >= max_retries {
-                            let error_msg = format!(
-                                "Final timeout waiting for registration transaction receipt {tx_hash} after {max_retries} attempts"
-                            );
-                            tracing::error!("{}", error_msg);
-                            tracing::error!(
-                                "All fallback methods exhausted for registration transaction"
-                            );
-                            return Err(error_msg);
-                        }
-                        tracing::warn!("Timeout on attempt {}, retrying...", retry_count);
-                        tokio::time::sleep(Duration::from_secs(3)).await; // Brief pause between retries
-                    }
-                }
-            }
-        }
-    };
+    // Wait for receipt with optimized polling (2s initial delay, 3s interval, tuned for Base)
+    let receipt = crate::services::transaction::poll_for_receipt(
+        &*state.provider.read_provider,
+        tx_hash,
+        120,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("{}", e);
+        sentry::capture_message(&e, sentry::Level::Error);
+        e
+    })?;
 
     let tx_hash = receipt.transaction_hash;
     tracing::info!(
@@ -532,56 +406,17 @@ pub async fn update_beacon(state: &AppState, request: UpdateBeaconRequest) -> Re
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Transaction hash: {:?}", tx_hash);
 
-    // Use get_receipt() with timeout and fallback to on-chain check
-    let receipt = match timeout(Duration::from_secs(60), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => {
-            tracing::info!("Transaction confirmed via get_receipt()");
-            receipt
-        }
-        Ok(Err(e)) => {
-            tracing::warn!("get_receipt() failed: {}", e);
-            tracing::info!("Falling back to on-chain transaction check...");
-
-            tracing::info!("Checking transaction {} on-chain...", tx_hash);
-
-            // Try to get the receipt directly from the read provider with timeout
-            match timeout(
-                Duration::from_secs(30),
-                state
-                    .provider
-                    .read_provider
-                    .get_transaction_receipt(tx_hash),
-            )
-            .await
-            {
-                Ok(Ok(Some(receipt))) => {
-                    tracing::info!("Transaction found on-chain via direct receipt lookup");
-                    receipt
-                }
-                Ok(Ok(None)) => {
-                    let error_msg =
-                        format!("Transaction {tx_hash} not found on-chain after timeout");
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-                Ok(Err(e)) => {
-                    let error_msg = format!("Failed to check transaction {tx_hash} on-chain: {e}");
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-                Err(_) => {
-                    let error_msg = format!("Timeout checking transaction {tx_hash} on-chain");
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-            }
-        }
-        Err(_) => {
-            let error_msg = format!("Timeout waiting for transaction {tx_hash} receipt");
-            tracing::error!("{}", error_msg);
-            return Err(error_msg);
-        }
-    };
+    // Wait for receipt with optimized polling
+    let receipt = crate::services::transaction::poll_for_receipt(
+        &*state.provider.read_provider,
+        tx_hash,
+        120,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("{}", e);
+        e
+    })?;
 
     tracing::info!(
         "Update transaction confirmed with hash: {:?}",

--- a/src/services/beacon/ecdsa.rs
+++ b/src/services/beacon/ecdsa.rs
@@ -244,23 +244,14 @@ pub async fn update_beacon_with_ecdsa(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Transaction hash: {:?}", tx_hash);
 
-    // 12. Wait for confirmation with timeout
-    let receipt = match timeout(Duration::from_secs(60), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => {
-            tracing::info!("Transaction confirmed via get_receipt()");
-            receipt
-        }
-        Ok(Err(e)) => {
-            let error_msg = format!("Failed to get transaction receipt: {e}");
-            tracing::error!("{}", error_msg);
-            return Err(error_msg);
-        }
-        Err(_) => {
-            let error_msg = format!("Timeout waiting for transaction {tx_hash} receipt");
-            tracing::error!("{}", error_msg);
-            return Err(error_msg);
-        }
-    };
+    // 12. Wait for confirmation with optimized polling (tuned for Base ~2s blocks)
+    let receipt =
+        crate::services::transaction::poll_for_receipt(&*state.provider.read_provider, tx_hash, 60)
+            .await
+            .map_err(|e| {
+                tracing::error!("{}", e);
+                e
+            })?;
 
     // 13. Validate transaction status
     if !receipt.status() {

--- a/src/services/beacon/ecdsa_deploy.rs
+++ b/src/services/beacon/ecdsa_deploy.rs
@@ -4,8 +4,6 @@
 //! setting the beaconator's PRIVATE_KEY signer as the designated signer.
 
 use alloy::primitives::Address;
-use std::time::Duration;
-use tokio::time::timeout;
 
 use crate::models::AppState;
 use crate::routes::IEcdsaVerifierFactory;
@@ -58,18 +56,13 @@ pub async fn create_ecdsa_verifier(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Verifier creation tx sent: {:?}", tx_hash);
 
-    // Wait for receipt
-    let receipt = match timeout(Duration::from_secs(120), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => receipt,
-        Ok(Err(e)) => {
-            return Err(format!("Failed to get verifier creation receipt: {e}"));
-        }
-        Err(_) => {
-            return Err(format!(
-                "Timeout waiting for verifier creation receipt (tx: {tx_hash})"
-            ));
-        }
-    };
+    // Wait for receipt with optimized polling
+    let receipt = crate::services::transaction::poll_for_receipt(
+        &*state.provider.read_provider,
+        tx_hash,
+        120,
+    )
+    .await?;
 
     // Check transaction status
     if !receipt.status() {

--- a/src/services/beacon/factory.rs
+++ b/src/services/beacon/factory.rs
@@ -4,8 +4,6 @@
 
 use alloy::primitives::{Address, U256};
 use std::str::FromStr;
-use std::time::Duration;
-use tokio::time::timeout;
 
 use crate::models::AppState;
 use crate::models::beacon_type::BeaconTypeConfig;
@@ -96,21 +94,13 @@ pub async fn create_lbcgbm_beacon(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("LBCGBM beacon creation tx sent: {:?}", tx_hash);
 
-    let receipt = match timeout(Duration::from_secs(120), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => receipt,
-        Ok(Err(e)) => return Err(format!("Failed to get LBCGBM beacon creation receipt: {e}")),
-        Err(_) => {
-            return Err(format!(
-                "Timeout waiting for LBCGBM beacon creation receipt (tx: {tx_hash})"
-            ));
-        }
-    };
-
-    if !receipt.status() {
-        return Err(format!(
-            "LBCGBM beacon creation transaction {tx_hash} reverted"
-        ));
-    }
+    let _receipt = crate::services::transaction::poll_for_successful_receipt(
+        &*state.provider.read_provider,
+        tx_hash,
+        "LBCGBM beacon creation",
+        120,
+    )
+    .await?;
 
     tracing::info!("LBCGBM beacon created at {}", beacon_address);
     sentry::capture_message(
@@ -198,25 +188,13 @@ pub async fn create_weighted_sum_composite_beacon(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Composite beacon creation tx sent: {:?}", tx_hash);
 
-    let receipt = match timeout(Duration::from_secs(120), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => receipt,
-        Ok(Err(e)) => {
-            return Err(format!(
-                "Failed to get composite beacon creation receipt: {e}"
-            ));
-        }
-        Err(_) => {
-            return Err(format!(
-                "Timeout waiting for composite beacon creation receipt (tx: {tx_hash})"
-            ));
-        }
-    };
-
-    if !receipt.status() {
-        return Err(format!(
-            "Composite beacon creation transaction {tx_hash} reverted"
-        ));
-    }
+    let _receipt = crate::services::transaction::poll_for_successful_receipt(
+        &*state.provider.read_provider,
+        tx_hash,
+        "composite beacon creation",
+        120,
+    )
+    .await?;
 
     tracing::info!("WeightedSumComposite beacon created at {}", beacon_address);
     sentry::capture_message(

--- a/src/services/beacon/modular.rs
+++ b/src/services/beacon/modular.rs
@@ -5,8 +5,6 @@
 
 use alloy::primitives::{Address, I256, U256};
 use std::str::FromStr;
-use std::time::Duration;
-use tokio::time::timeout;
 
 use crate::AlloyProvider;
 use crate::models::AppState;
@@ -158,7 +156,7 @@ async fn create_identity_beacon_modular(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Identity beacon creation tx sent: {:?}", tx_hash);
 
-    wait_for_receipt("identity beacon creation", tx_hash, pending_tx).await?;
+    wait_for_receipt(provider, "identity beacon creation", tx_hash).await?;
 
     tracing::info!("Identity beacon created at {}", beacon_addr);
     sentry::capture_message(
@@ -251,7 +249,7 @@ async fn create_standalone_beacon_modular(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Standalone beacon creation tx sent: {:?}", tx_hash);
 
-    wait_for_receipt("standalone beacon creation", tx_hash, pending_tx).await?;
+    wait_for_receipt(provider, "standalone beacon creation", tx_hash).await?;
 
     tracing::info!("Standalone beacon created at {}", beacon_addr);
     sentry::capture_message(
@@ -334,7 +332,7 @@ async fn create_composite_beacon_modular(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Composite beacon creation tx sent: {:?}", tx_hash);
 
-    wait_for_receipt("composite beacon creation", tx_hash, pending_tx).await?;
+    wait_for_receipt(provider, "composite beacon creation", tx_hash).await?;
 
     tracing::info!("Composite beacon created at {}", beacon_addr);
     sentry::capture_message(
@@ -438,7 +436,7 @@ async fn create_group_beacon_modular(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Group manager creation tx sent: {:?}", tx_hash);
 
-    wait_for_receipt("group manager creation", tx_hash, pending_tx).await?;
+    wait_for_receipt(provider, "group manager creation", tx_hash).await?;
 
     tracing::info!("Group manager created at {}", beacon_addr);
     sentry::capture_message(
@@ -498,7 +496,7 @@ async fn create_verifier(state: &AppState, provider: &AlloyProvider) -> Result<A
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("ECDSA verifier creation tx sent: {:?}", tx_hash);
 
-    wait_for_receipt("ECDSA verifier creation", tx_hash, pending_tx).await?;
+    wait_for_receipt(provider, "ECDSA verifier creation", tx_hash).await?;
 
     tracing::info!("ECDSAVerifier created at {}", verifier_addr);
     Ok(verifier_addr)
@@ -548,7 +546,7 @@ async fn create_preprocessor(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("Identity preprocessor creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("identity preprocessor creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "identity preprocessor creation", tx_hash).await?;
             addr
         }
         PreprocessorSpec::Threshold => {
@@ -577,7 +575,7 @@ async fn create_preprocessor(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("Threshold preprocessor creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("threshold preprocessor creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "threshold preprocessor creation", tx_hash).await?;
             addr
         }
         PreprocessorSpec::TernaryToBinary => {
@@ -613,12 +611,7 @@ async fn create_preprocessor(
                 tx_hash
             );
 
-            wait_for_receipt(
-                "ternary-to-binary preprocessor creation",
-                tx_hash,
-                pending_tx,
-            )
-            .await?;
+            wait_for_receipt(provider, "ternary-to-binary preprocessor creation", tx_hash).await?;
             addr
         }
         PreprocessorSpec::Argmax => {
@@ -646,7 +639,7 @@ async fn create_preprocessor(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("Argmax preprocessor creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("argmax preprocessor creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "argmax preprocessor creation", tx_hash).await?;
             addr
         }
     };
@@ -719,7 +712,7 @@ async fn create_base_fn(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("CGBM base function creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("CGBM base function creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "CGBM base function creation", tx_hash).await?;
             addr
         }
         BaseFnSpec::DGBM => {
@@ -756,7 +749,7 @@ async fn create_base_fn(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("DGBM base function creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("DGBM base function creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "DGBM base function creation", tx_hash).await?;
             addr
         }
     };
@@ -808,7 +801,7 @@ async fn create_transform(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("Bounded transform creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("bounded transform creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "bounded transform creation", tx_hash).await?;
             addr
         }
         TransformSpec::Unbounded => {
@@ -841,7 +834,7 @@ async fn create_transform(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("Unbounded transform creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("unbounded transform creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "unbounded transform creation", tx_hash).await?;
             addr
         }
     };
@@ -891,7 +884,7 @@ async fn create_composer(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("WeightedSum composer creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("weighted sum composer creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "weighted sum composer creation", tx_hash).await?;
             addr
         }
     };
@@ -947,7 +940,7 @@ async fn create_group_fn(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("Dominance group function creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("dominance group function creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "dominance group function creation", tx_hash).await?;
             addr
         }
         GroupFnSpec::RelativeDominance => {
@@ -1008,9 +1001,9 @@ async fn create_group_fn(
             );
 
             wait_for_receipt(
+                provider,
                 "relative dominance group function creation",
                 tx_hash,
-                pending_tx,
             )
             .await?;
             addr
@@ -1054,9 +1047,9 @@ async fn create_group_fn(
             );
 
             wait_for_receipt(
+                provider,
                 "continuous allocation group function creation",
                 tx_hash,
-                pending_tx,
             )
             .await?;
             addr
@@ -1100,9 +1093,9 @@ async fn create_group_fn(
             );
 
             wait_for_receipt(
+                provider,
                 "discrete allocation group function creation",
                 tx_hash,
-                pending_tx,
             )
             .await?;
             addr
@@ -1155,7 +1148,7 @@ async fn create_group_transform(
             let tx_hash = *pending_tx.tx_hash();
             tracing::info!("Softmax group transform creation tx sent: {:?}", tx_hash);
 
-            wait_for_receipt("softmax group transform creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "softmax group transform creation", tx_hash).await?;
             addr
         }
         GroupTransformSpec::GMNormalize => {
@@ -1190,7 +1183,7 @@ async fn create_group_transform(
                 tx_hash
             );
 
-            wait_for_receipt("gm-normalize group transform creation", tx_hash, pending_tx).await?;
+            wait_for_receipt(provider, "gm-normalize group transform creation", tx_hash).await?;
             addr
         }
     };
@@ -1215,31 +1208,16 @@ fn require_param_vec<T: Clone>(val: &Option<Vec<T>>, name: &str) -> Result<Vec<T
         .ok_or_else(|| format!("Missing required parameter: {name}"))
 }
 
-/// Wait for a pending transaction receipt with a 120-second timeout.
+/// Wait for a pending transaction receipt using optimized polling (tuned for Base ~2s blocks).
 ///
 /// Checks the receipt status and returns an error if the transaction reverted.
 async fn wait_for_receipt(
+    provider: &impl alloy::providers::Provider,
     description: &str,
     tx_hash: alloy::primitives::TxHash,
-    pending_tx: alloy::providers::PendingTransactionBuilder<alloy::network::Ethereum>,
 ) -> Result<(), String> {
-    let receipt = match timeout(Duration::from_secs(120), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => receipt,
-        Ok(Err(e)) => {
-            return Err(format!("Failed to get {} receipt: {e}", description));
-        }
-        Err(_) => {
-            return Err(format!(
-                "Timeout waiting for {} receipt (tx: {tx_hash})",
-                description
-            ));
-        }
-    };
-
-    if !receipt.status() {
-        return Err(format!("{} transaction {tx_hash} reverted", description));
-    }
-
+    crate::services::transaction::poll_for_successful_receipt(provider, tx_hash, description, 120)
+        .await?;
     Ok(())
 }
 

--- a/src/services/beacon/verifiable.rs
+++ b/src/services/beacon/verifiable.rs
@@ -3,16 +3,13 @@
 //! Deploys IdentityBeacon contracts using pre-compiled bytecode with
 //! constructor args (IVerifier verifier, uint256 initialIndex).
 
+use crate::models::AppState;
+use crate::services::wallet::WalletHandle;
 use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, Bytes, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use alloy::sol_types::SolValue;
-use std::time::Duration;
-use tokio::time::timeout;
-
-use crate::models::AppState;
-use crate::services::wallet::WalletHandle;
 
 /// Deploys an IdentityBeacon contract with the given verifier and initial index.
 ///
@@ -59,23 +56,14 @@ pub async fn deploy_identity_beacon(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Beacon deployment tx sent: {:?}", tx_hash);
 
-    // Wait for receipt
-    let receipt = match timeout(Duration::from_secs(120), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => receipt,
-        Ok(Err(e)) => {
-            return Err(format!("Failed to get beacon deployment receipt: {e}"));
-        }
-        Err(_) => {
-            return Err(format!(
-                "Timeout waiting for beacon deployment receipt (tx: {tx_hash})"
-            ));
-        }
-    };
-
-    // Check transaction status
-    if !receipt.status() {
-        return Err(format!("Beacon deployment transaction {tx_hash} reverted"));
-    }
+    // Wait for receipt with optimized polling
+    let receipt = crate::services::transaction::poll_for_successful_receipt(
+        &*state.provider.read_provider,
+        tx_hash,
+        "beacon deployment",
+        120,
+    )
+    .await?;
 
     // Extract deployed contract address
     let beacon_address = receipt.contract_address.ok_or_else(|| {

--- a/src/services/perp/core.rs
+++ b/src/services/perp/core.rs
@@ -1,7 +1,5 @@
 use alloy::primitives::{Address, FixedBytes, Signed, U256, Uint};
 use alloy::providers::Provider;
-use std::time::Duration;
-use tokio::time::timeout;
 use tracing;
 
 use super::super::transaction::events::{
@@ -277,62 +275,17 @@ pub async fn deploy_perp_for_beacon(
     let pending_tx_hash = *pending_tx.tx_hash();
     tracing::info!("Transaction hash (pending): {:?}", pending_tx_hash);
 
-    // Use get_receipt() with timeout and fallback like beacon endpoints
-    let receipt = match timeout(Duration::from_secs(120), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => {
-            tracing::info!("Perp deployment confirmed via get_receipt()");
-            receipt
-        }
-        Ok(Err(e)) => {
-            tracing::warn!("get_receipt() failed for perp deployment: {}", e);
-            tracing::info!("Falling back to on-chain perp deployment check...");
-
-            // Try to get the receipt directly from the read provider with timeout
-            match timeout(
-                Duration::from_secs(30),
-                state
-                    .provider
-                    .read_provider
-                    .get_transaction_receipt(pending_tx_hash),
-            )
-            .await
-            {
-                Ok(Ok(Some(receipt))) => {
-                    tracing::info!("Perp deployment confirmed via on-chain check");
-                    receipt
-                }
-                Ok(Ok(None)) => {
-                    let error_msg =
-                        format!("Perp deployment transaction {pending_tx_hash} not found on-chain");
-                    tracing::error!("{}", error_msg);
-                    sentry::capture_message(&error_msg, sentry::Level::Error);
-                    return Err(error_msg);
-                }
-                Ok(Err(e)) => {
-                    let error_msg = format!(
-                        "Failed to check perp deployment transaction {pending_tx_hash} on-chain: {e}"
-                    );
-                    tracing::error!("{}", error_msg);
-                    sentry::capture_message(&error_msg, sentry::Level::Error);
-                    return Err(error_msg);
-                }
-                Err(_) => {
-                    let error_msg = format!(
-                        "Timeout checking perp deployment transaction {pending_tx_hash} on-chain"
-                    );
-                    tracing::error!("{}", error_msg);
-                    sentry::capture_message(&error_msg, sentry::Level::Error);
-                    return Err(error_msg);
-                }
-            }
-        }
-        Err(_) => {
-            let error_msg = "Timeout waiting for perp deployment receipt".to_string();
-            tracing::error!("{}", error_msg);
-            sentry::capture_message(&error_msg, sentry::Level::Error);
-            return Err(error_msg);
-        }
-    };
+    let receipt = crate::services::transaction::poll_for_receipt(
+        &*state.provider.read_provider,
+        pending_tx_hash,
+        120,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("{}", e);
+        sentry::capture_message(&e, sentry::Level::Error);
+        e
+    })?;
 
     let tx_hash = receipt.transaction_hash;
     tracing::info!("Perp deployment transaction confirmed successfully!");
@@ -488,136 +441,17 @@ pub async fn deposit_liquidity_for_perp(
     let approval_tx_hash = *pending_approval.tx_hash();
     tracing::info!("USDC approval transaction hash: {:?}", approval_tx_hash);
 
-    // Use get_receipt() with extended timeout for USDC approvals (Base can be slow)
-    let approval_receipt = match timeout(Duration::from_secs(150), pending_approval.get_receipt())
-        .await
-    {
-        Ok(Ok(receipt)) => {
-            tracing::info!("USDC approval confirmed via get_receipt()");
-            receipt
-        }
-        Ok(Err(e)) => {
-            tracing::warn!("get_receipt() failed for USDC approval: {}", e);
-            tracing::info!("Falling back to on-chain approval check...");
-
-            // Try to get the receipt directly from the read provider with timeout
-            match timeout(
-                Duration::from_secs(60),
-                state
-                    .provider
-                    .read_provider
-                    .get_transaction_receipt(approval_tx_hash),
-            )
-            .await
-            {
-                Ok(Ok(Some(receipt))) => {
-                    tracing::info!("USDC approval confirmed via on-chain check");
-                    receipt
-                }
-                Ok(Ok(None)) => {
-                    let error_msg =
-                        format!("USDC approval transaction {approval_tx_hash} not found on-chain");
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-                Ok(Err(e)) => {
-                    let error_msg = format!(
-                        "Failed to check USDC approval transaction {approval_tx_hash} on-chain: {e}"
-                    );
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-                Err(_) => {
-                    let error_msg = format!(
-                        "Timeout checking USDC approval transaction {approval_tx_hash} on-chain"
-                    );
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-            }
-        }
-        Err(_) => {
-            tracing::warn!(
-                "Initial get_receipt() timed out for USDC approval, trying extended fallback..."
-            );
-            tracing::info!(
-                "Checking USDC approval transaction {} on-chain with extended timeout...",
-                approval_tx_hash
-            );
-
-            // Extended fallback: retry with progressive timeouts (15s, 30s, 60s) for Base network
-            let mut retry_count = 0;
-            let max_retries = 3;
-            let timeout_seconds = [15u64, 30u64, 60u64]; // Progressive timeout pattern
-
-            loop {
-                retry_count += 1;
-                let current_timeout = timeout_seconds[retry_count - 1];
-                tracing::info!(
-                    "USDC approval receipt attempt {}/{} ({}s timeout)",
-                    retry_count,
-                    max_retries,
-                    current_timeout
-                );
-
-                match timeout(
-                    Duration::from_secs(current_timeout),
-                    state
-                        .provider
-                        .read_provider
-                        .get_transaction_receipt(approval_tx_hash),
-                )
-                .await
-                {
-                    Ok(Ok(Some(receipt))) => {
-                        tracing::info!(
-                            "USDC approval found on-chain via extended fallback (attempt {})",
-                            retry_count
-                        );
-                        break receipt;
-                    }
-                    Ok(Ok(None)) => {
-                        if retry_count >= max_retries {
-                            let error_msg = format!(
-                                "USDC approval transaction {approval_tx_hash} not found on-chain after {max_retries} attempts"
-                            );
-                            tracing::error!("{}", error_msg);
-                            tracing::error!("This could indicate:");
-                            tracing::error!("  - USDC approval transaction was dropped/replaced");
-                            tracing::error!("  - Network issues prevented confirmation");
-                            tracing::error!("  - Transaction is still pending (check gas price)");
-                            tracing::error!("  - Base network congestion causing delays");
-                            return Err(error_msg);
-                        }
-                        tracing::warn!(
-                            "USDC approval not found on attempt {}, retrying...",
-                            retry_count
-                        );
-                        tokio::time::sleep(Duration::from_secs(5)).await; // Brief pause between retries
-                    }
-                    Ok(Err(e)) => {
-                        let error_msg = format!(
-                            "Failed to check USDC approval transaction {approval_tx_hash} on-chain: {e}"
-                        );
-                        tracing::error!("{}", error_msg);
-                        return Err(error_msg);
-                    }
-                    Err(_) => {
-                        if retry_count >= max_retries {
-                            let error_msg = format!(
-                                "Final timeout waiting for USDC approval receipt {approval_tx_hash} after {max_retries} attempts"
-                            );
-                            tracing::error!("{}", error_msg);
-                            tracing::error!("All fallback methods exhausted for USDC approval");
-                            return Err(error_msg);
-                        }
-                        tracing::warn!("Timeout on attempt {}, retrying...", retry_count);
-                        tokio::time::sleep(Duration::from_secs(5)).await; // Brief pause between retries
-                    }
-                }
-            }
-        }
-    };
+    let approval_receipt = crate::services::transaction::poll_for_receipt(
+        &*state.provider.read_provider,
+        approval_tx_hash,
+        150,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("{}", e);
+        sentry::capture_message(&e, sentry::Level::Error);
+        e
+    })?;
 
     // Send the openMakerPosition transaction
     tracing::info!("Opening maker position with wallet {}", wallet_address);
@@ -683,59 +517,17 @@ pub async fn deposit_liquidity_for_perp(
     let deposit_tx_hash = *pending_tx.tx_hash();
     tracing::info!("Liquidity deposit transaction hash: {:?}", deposit_tx_hash);
 
-    // Use get_receipt() with timeout and fallback like beacon endpoints
-    let receipt = match timeout(Duration::from_secs(90), pending_tx.get_receipt()).await {
-        Ok(Ok(receipt)) => {
-            tracing::info!("Liquidity deposit confirmed via get_receipt()");
-            receipt
-        }
-        Ok(Err(e)) => {
-            tracing::warn!("get_receipt() failed for liquidity deposit: {}", e);
-            tracing::info!("Falling back to on-chain deposit check...");
-
-            // Try to get the receipt directly from the read provider with timeout
-            match timeout(
-                Duration::from_secs(30),
-                state
-                    .provider
-                    .read_provider
-                    .get_transaction_receipt(deposit_tx_hash),
-            )
-            .await
-            {
-                Ok(Ok(Some(receipt))) => {
-                    tracing::info!("Liquidity deposit confirmed via on-chain check");
-                    receipt
-                }
-                Ok(Ok(None)) => {
-                    let error_msg = format!(
-                        "Liquidity deposit transaction {deposit_tx_hash} not found on-chain"
-                    );
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-                Ok(Err(e)) => {
-                    let error_msg = format!(
-                        "Failed to check liquidity deposit transaction {deposit_tx_hash} on-chain: {e}"
-                    );
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-                Err(_) => {
-                    let error_msg = format!(
-                        "Timeout checking liquidity deposit transaction {deposit_tx_hash} on-chain"
-                    );
-                    tracing::error!("{}", error_msg);
-                    return Err(error_msg);
-                }
-            }
-        }
-        Err(_) => {
-            let error_msg = "Timeout waiting for liquidity deposit receipt".to_string();
-            tracing::error!("{}", error_msg);
-            return Err(error_msg);
-        }
-    };
+    let receipt = crate::services::transaction::poll_for_receipt(
+        &*state.provider.read_provider,
+        deposit_tx_hash,
+        90,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("{}", e);
+        sentry::capture_message(&e, sentry::Level::Error);
+        e
+    })?;
 
     tracing::info!(
         "Liquidity deposit transaction confirmed with hash: {:?}",

--- a/src/services/rpc.rs
+++ b/src/services/rpc.rs
@@ -63,9 +63,11 @@ impl RpcConfig {
         Ok(provider)
     }
 
-    /// Build a read-only provider from a URL (no wallet, for queries only)
+    /// Build a read-only provider from a URL (no wallet or fillers, for queries only).
+    /// Uses ProviderBuilder::default() to skip recommended fillers (Gas, Nonce,
+    /// BlobGas, ChainId) since read operations don't need them.
     pub fn build_read_only_provider(url: &str) -> Result<ReadOnlyProvider, String> {
-        let provider = ProviderBuilder::new().connect_http(
+        let provider = ProviderBuilder::default().connect_http(
             url.parse()
                 .map_err(|e| format!("Invalid RPC URL '{url}': {e}"))?,
         );

--- a/src/services/transaction/mod.rs
+++ b/src/services/transaction/mod.rs
@@ -1,7 +1,9 @@
 pub mod events;
 pub mod execution;
 pub mod multicall;
+pub mod receipt;
 
 pub use events::*;
 pub use execution::*;
 pub use multicall::*;
+pub use receipt::*;

--- a/src/services/transaction/multicall.rs
+++ b/src/services/transaction/multicall.rs
@@ -64,23 +64,17 @@ pub async fn execute_multicall(
             error_msg
         })?;
 
-    tracing::info!("Multicall transaction sent, awaiting confirmation...");
+    let tx_hash = *pending_tx.tx_hash();
+    tracing::info!("Multicall transaction sent (tx: {tx_hash}), awaiting confirmation...");
 
-    // Wait for transaction confirmation with timeout
+    // Wait for transaction confirmation with optimized polling
     let receipt =
-        tokio::time::timeout(std::time::Duration::from_secs(30), pending_tx.get_receipt())
+        crate::services::transaction::poll_for_receipt(&*state.provider.read_provider, tx_hash, 30)
             .await
-            .map_err(|_| {
-                let error_msg = "Timeout waiting for multicall transaction receipt";
-                tracing::error!("{}", error_msg);
-                sentry::capture_message(error_msg, sentry::Level::Warning);
-                error_msg.to_string()
-            })?
             .map_err(|e| {
-                let error_msg = format!("Failed to get multicall transaction receipt: {e}");
-                tracing::error!("{}", error_msg);
-                sentry::capture_message(&error_msg, sentry::Level::Error);
-                error_msg
+                tracing::error!("{}", e);
+                sentry::capture_message(&e, sentry::Level::Error);
+                e
             })?;
 
     let tx_hash = receipt.transaction_hash;

--- a/src/services/transaction/receipt.rs
+++ b/src/services/transaction/receipt.rs
@@ -1,0 +1,66 @@
+//! Optimized receipt polling for Base network (~2s block time).
+//!
+//! Replaces Alloy's default `get_receipt()` polling which may poll too aggressively,
+//! wasting RPC compute units. This implementation waits 2s before the first poll
+//! (matching Base block time) and then polls every 3s.
+
+use alloy::primitives::TxHash;
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionReceipt;
+use std::time::{Duration, Instant};
+
+/// Poll for a transaction receipt with intervals tuned to Base's ~2s block time.
+///
+/// Waits 2s before the first poll, then retries every 3s until the receipt is found
+/// or the timeout is reached. Returns the receipt on success.
+pub async fn poll_for_receipt(
+    provider: &impl Provider,
+    tx_hash: TxHash,
+    timeout_secs: u64,
+) -> Result<TransactionReceipt, String> {
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+
+    // Initial wait: ~1 Base block time before first poll
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    loop {
+        match provider.get_transaction_receipt(tx_hash).await {
+            Ok(Some(receipt)) => {
+                tracing::info!("Transaction {tx_hash} confirmed via receipt poll");
+                return Ok(receipt);
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "Timeout waiting for transaction {tx_hash} receipt after {timeout_secs}s"
+                    ));
+                }
+                // Poll every 3s (slightly more than Base block time to avoid wasted polls)
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+            Err(e) => {
+                return Err(format!(
+                    "RPC error polling for transaction {tx_hash} receipt: {e}"
+                ));
+            }
+        }
+    }
+}
+
+/// Poll for a receipt and check that the transaction succeeded (did not revert).
+///
+/// Convenience wrapper over `poll_for_receipt` that also validates the receipt status.
+pub async fn poll_for_successful_receipt(
+    provider: &impl Provider,
+    tx_hash: TxHash,
+    description: &str,
+    timeout_secs: u64,
+) -> Result<TransactionReceipt, String> {
+    let receipt = poll_for_receipt(provider, tx_hash, timeout_secs).await?;
+
+    if !receipt.status() {
+        return Err(format!("{description} transaction {tx_hash} reverted"));
+    }
+
+    Ok(receipt)
+}

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -203,10 +203,10 @@ pub async fn create_test_wallet_manager() -> Arc<WalletManager> {
     }
 }
 
-/// Build a read-only provider (without wallet) for test purposes
+/// Build a read-only provider (without wallet or fillers) for test purposes
 fn build_test_read_only_provider(rpc_url: &str) -> Arc<ReadOnlyProvider> {
     Arc::new(
-        ProviderBuilder::new().connect_http(rpc_url.parse().expect("Invalid RPC URL for test")),
+        ProviderBuilder::default().connect_http(rpc_url.parse().expect("Invalid RPC URL for test")),
     )
 }
 


### PR DESCRIPTION
## Summary
- Strip unnecessary fillers (GasFiller, NonceFiller, BlobGasFiller) from ReadOnlyProvider since read operations don't need them
- Replace Alloy's default receipt polling with manual polling tuned for Base's ~2s block time (2s initial delay, 3s interval)
- Consolidate 13 receipt-waiting patterns across the codebase into a shared `poll_for_receipt` utility
- Net reduction of ~370 lines by removing duplicated fallback/retry receipt logic

## Context
Investigation of a $500 Alchemy invoice revealed another service was sharing our RPC key (now rotated). The beaconator alone uses ~26M CU/month (within the 30M free tier). These optimizations provide ~40% headroom as beacon count grows.

## Test plan
- [x] `make fmt-check` passes
- [x] `make lint` (clippy) passes
- [x] `make test-fast` passes (7/7 unit tests)
- [ ] `make test-integration` with Anvil (requires local setup)
- [ ] Monitor Alchemy dashboard post-deploy to confirm CU stays within free tier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced transaction confirmation reliability through improved receipt polling across beacon deployments, perpetual funding, and wallet operations.
  * Optimized read-only provider performance by streamlining provider configuration.

* **Refactor**
  * Consolidated transaction confirmation logic for better consistency and maintainability across different transaction types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->