### PR TITLE
Allow CHAIN_ID env var to override default chain selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Test Docker image
         run: |
           # Use host network so container can reach Redis service
-          docker run --rm -d --name test-beaconator --network host \
+          docker run -d --name test-beaconator --network host \
             -e RPC_URL=https://mainnet.base.org \
             -e PRIVATE_KEY=0000000000000000000000000000000000000000000000000000000000000001 \
             -e SENTRY_DSN=https://test@test.ingest.sentry.io/test \
@@ -234,8 +234,13 @@ jobs:
             -e BEACONATOR_ADMIN_TOKEN=test_admin_token_123 \
             the-beaconator:latest
           sleep 15
-          curl -f http://localhost:8000/ || (docker logs test-beaconator && exit 1)
-          docker stop test-beaconator
+          if ! curl -f http://localhost:8000/; then
+            echo "--- Container logs ---"
+            docker logs test-beaconator
+            docker rm -f test-beaconator
+            exit 1
+          fi
+          docker rm -f test-beaconator
 
       - name: Move cache
         run: |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,15 +175,22 @@ pub async fn create_rocket() -> Rocket<Build> {
         .expect("Failed to parse ETH_TRANSFER_LIMIT");
 
     // Get environment configuration and chain ID
+    // CHAIN_ID env var overrides the default ENV-based mapping, enabling
+    // deployment to chains like Arbitrum Sepolia (421614) while keeping ENV=testnet.
     let env_type = &rpc_config.env_type;
-    let chain_id = match env_type.to_lowercase().as_str() {
-        "testnet" => 84532u64,  // Base Sepolia testnet
-        "mainnet" => 8453u64,   // Base mainnet
-        "localnet" => 84532u64, // Use testnet chain ID for local development/CI
-        _ => panic!(
-            "Invalid ENV value '{env_type}'. Must be either 'mainnet', 'testnet', or 'localnet'"
-        ),
-    };
+    let chain_id = env::var("CHAIN_ID")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or_else(|| {
+            match env_type.to_lowercase().as_str() {
+                "testnet" => 84532u64,  // Base Sepolia testnet
+                "mainnet" => 8453u64,   // Base mainnet
+                "localnet" => 84532u64, // Use testnet chain ID for local development/CI
+                _ => panic!(
+                    "Invalid ENV value '{env_type}'. Must be either 'mainnet', 'testnet', or 'localnet'"
+                ),
+            }
+        });
 
     // Get the RPC URL for storing in AppState (used by WalletHandle to build providers)
     let rpc_url = rpc_config.rpc_url().to_string();


### PR DESCRIPTION
## Summary
- Adds optional `CHAIN_ID` env var that overrides the hardcoded `ENV -> chain_id` mapping
- Enables deploying the beaconator to non-Base chains (e.g. Arbitrum Sepolia 421614) while keeping `ENV=testnet`
- Fully backward-compatible: existing deployments without `CHAIN_ID` behave identically

## Context
We're deploying beacons to Arbitrum Sepolia as Phase 1 of the Base -> Arbitrum migration. The Arbitrum beaconator instance will set `CHAIN_ID=421614` alongside `ENV=testnet`.

## Test plan
- [x] `make fmt-check` passes
- [x] `make lint` passes
- [x] `make test-fast` passes (183 unit + 7 integration)
- [ ] Deploy `the-beaconator-arb` on Railway with `CHAIN_ID=421614` and verify health

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain ID can now be overridden via a CHAIN_ID environment variable, allowing explicit network selection instead of relying solely on default mappings.

* **Chores**
  * CI container health-check behavior improved: more robust failure logging and explicit container removal on success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->