### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . .
 RUN cargo build --release
 
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 # Install ca-certificates for HTTPS requests
 RUN apt-get update && apt-get install -y ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
 WORKDIR /app


### PR DESCRIPTION
The builder stage uses `rustlang/rust:nightly`, which is now based on Debian Trixie (glibc 2.38+). The runtime stage was on `debian:bookworm-slim` (glibc 2.36), so the compiled binary fails on container start with:

    ./the-beaconator: /lib/x86_64-linux-gnu/libc.so.6: version
    `GLIBC_2.38' not found (required by ./the-beaconator)

This crash-loops the testnet pod and Railway returns 502s for every request. Switching the runtime to `debian:trixie-slim` aligns glibc with the builder. No Rust toolchain change needed (nightly is still required — see the prashanth-vibecoding branch's rust-toolchain.toml).