### PR TITLE
Surface panic messages and pre-flight env audit at startup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,182 @@ fn serve_openapi_spec(
 ///
 /// Initializes the application state, loads configuration from environment variables,
 /// sets up providers and wallets, and mounts all routes.
+/// Pre-flight audit of every env var the-beaconator reads at startup.
+///
+/// Logs each variable's presence and shape BEFORE any code tries to parse them, so the
+/// operator sees the full picture of what the container thinks its config is in a single
+/// log dump — even when the next step is going to panic. This is verbose by design:
+/// startup crashes are fatal-by-restart-loop, and the per-deploy debug cost of one extra
+/// log block is dwarfed by the cost of round-tripping through redeploys to find a typo.
+///
+/// **Secrets are never logged in plaintext.** For private keys, tokens, DSNs, and any URL
+/// known to carry an API key, we log only `<set, len=N>` plus a whitespace warning if the
+/// value would trim to a different length. For addresses and other non-sensitive vars the
+/// raw value is logged so parse failures are obvious.
+fn audit_environment() {
+    use std::env;
+
+    // Categorise every env var the-beaconator reads. ADD NEW ENTRIES HERE whenever a new
+    // env var is plumbed in src/lib.rs — keeping the audit in sync with reality is the
+    // whole point.
+    const ADDRESS_VARS_REQUIRED: &[&str] = &[
+        "PERPCITY_REGISTRY_ADDRESS",
+        "PERP_MANAGER_ADDRESS",
+        "USDC_ADDRESS",
+        "ECDSA_VERIFIER_FACTORY_ADDRESS",
+    ];
+    const ADDRESS_VARS_OPTIONAL: &[&str] = &[
+        "MULTICALL3_ADDRESS",
+        "LBCGBM_FACTORY_ADDRESS",
+        "WEIGHTED_SUM_COMPOSITE_FACTORY_ADDRESS",
+        "SAFE_ADDRESS",
+    ];
+    const SECRET_VARS_REQUIRED: &[&str] = &[
+        "RPC_URL",
+        "PRIVATE_KEY",
+        "WALLET_PRIVATE_KEYS",
+        "BEACONATOR_ACCESS_TOKEN",
+        "BEACONATOR_ADMIN_TOKEN",
+        "REDIS_URL",
+    ];
+    const SECRET_VARS_OPTIONAL: &[&str] = &["SENTRY_DSN", "SAFE_TX_SERVICE_URL"];
+    const PLAIN_VARS: &[&str] = &[
+        "ENV",
+        "USDC_TRANSFER_LIMIT",
+        "ETH_TRANSFER_LIMIT",
+        "BEACONATOR_INSTANCE_ID",
+        "RUST_LOG",
+    ];
+
+    tracing::info!("=== Pre-flight environment audit ===");
+
+    // Addresses: log raw value (addresses are public), pre-validate parse, warn on
+    // hidden whitespace.
+    for &key in ADDRESS_VARS_REQUIRED {
+        audit_address(key, true);
+    }
+    for &key in ADDRESS_VARS_OPTIONAL {
+        audit_address(key, false);
+    }
+
+    // Secrets: log only length + whitespace warning. NEVER the value.
+    for &key in SECRET_VARS_REQUIRED {
+        audit_secret(key, true);
+    }
+    for &key in SECRET_VARS_OPTIONAL {
+        audit_secret(key, false);
+    }
+
+    // Plain non-sensitive scalars.
+    for &key in PLAIN_VARS {
+        audit_plain(key);
+    }
+
+    // Special case: PRIVATE_KEY's expected length. secp256k1 keys are 32 bytes = 64 hex
+    // characters, optionally with `0x` prefix. Anything else is the bug we keep seeing.
+    if let Ok(v) = env::var("PRIVATE_KEY") {
+        let trimmed = v.trim();
+        let len = trimmed.len();
+        if len != 64 && len != 66 {
+            tracing::error!(
+                "PRIVATE_KEY length is {len} (after trim) — expected 64 (raw hex) or 66 (with 0x prefix). \
+                 PRIVATE_KEY parse WILL fail. Generate a fresh key with `openssl rand -hex 32`."
+            );
+        }
+    }
+
+    // Same check for each comma-separated entry in WALLET_PRIVATE_KEYS.
+    if let Ok(v) = env::var("WALLET_PRIVATE_KEYS") {
+        for (i, raw) in v.split(',').enumerate() {
+            let trimmed = raw.trim();
+            let len = trimmed.len();
+            if !trimmed.is_empty() && len != 64 && len != 66 {
+                tracing::error!(
+                    "WALLET_PRIVATE_KEYS[{i}] length is {len} (after trim) — expected 64 or 66. \
+                     This entry WILL fail to parse."
+                );
+            }
+        }
+    }
+
+    tracing::info!("=== End pre-flight environment audit ===");
+}
+
+fn audit_address(key: &str, required: bool) {
+    use std::env;
+    use std::str::FromStr;
+    match env::var(key) {
+        Ok(raw) => {
+            let trimmed = raw.trim();
+            let whitespace_note = if raw.len() != trimmed.len() {
+                format!(
+                    " WARNING: raw_len={} trimmed_len={} — hidden leading/trailing whitespace!",
+                    raw.len(),
+                    trimmed.len()
+                )
+            } else {
+                String::new()
+            };
+            match Address::from_str(trimmed) {
+                Ok(parsed) => tracing::info!(
+                    "  {key} = {parsed} (parses OK, len={}){whitespace_note}",
+                    trimmed.len()
+                ),
+                Err(e) => tracing::error!(
+                    "  {key} = {trimmed:?} FAILS to parse as Address: {e}{whitespace_note}"
+                ),
+            }
+        }
+        Err(_) if required => tracing::error!("  {key} = (NOT SET — REQUIRED)"),
+        Err(_) => tracing::info!("  {key} = (not set, optional)"),
+    }
+}
+
+fn audit_secret(key: &str, required: bool) {
+    use std::env;
+    match env::var(key) {
+        Ok(raw) => {
+            let trimmed_len = raw.trim().len();
+            let whitespace_note = if raw.len() != trimmed_len {
+                format!(
+                    " WARNING: raw_len={} trimmed_len={trimmed_len} — hidden whitespace; likely cause of parse errors!",
+                    raw.len(),
+                )
+            } else {
+                String::new()
+            };
+            tracing::info!("  {key} = <set, len={trimmed_len}>{whitespace_note}");
+        }
+        Err(_) if required => tracing::error!("  {key} = (NOT SET — REQUIRED)"),
+        Err(_) => tracing::info!("  {key} = (not set, optional)"),
+    }
+}
+
+fn audit_plain(key: &str) {
+    use std::env;
+    match env::var(key) {
+        Ok(raw) => {
+            let trimmed = raw.trim();
+            let whitespace_note = if raw.len() != trimmed.len() {
+                format!(" WARNING: hidden whitespace, raw_len={}", raw.len())
+            } else {
+                String::new()
+            };
+            tracing::info!("  {key} = {trimmed:?}{whitespace_note}");
+        }
+        Err(_) => tracing::info!("  {key} = (not set)"),
+    }
+}
+
 pub async fn create_rocket() -> Rocket<Build> {
     // Load and cache environment variables
     dotenvy::dotenv().ok();
+
+    // Verbose pre-flight audit of every env var the-beaconator reads. Runs BEFORE any
+    // parse attempt so the operator can see every problem in one log dump even when the
+    // next step is going to panic. Secrets are never logged in plaintext (only lengths +
+    // whitespace warnings). See `audit_environment` above.
+    audit_environment();
 
     // Load RPC configuration from environment
     let rpc_config = services::rpc::RpcConfig::from_env()

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,20 +46,32 @@ async fn rocket() -> _ {
         None
     };
 
-    // Install panic handler to log panics
+    // Install panic handler to log panics.
+    //
+    // The previous version logged `panic_info` via Debug, which only prints
+    // `PanicHookInfo { payload: Any { .. }, location: ... }` — the actual panic message
+    // never made it to the logs. We now downcast `payload()` to recover the message
+    // string that `panic!("...")` and `.expect("...")` write.
     std::panic::set_hook(Box::new(|panic_info| {
-        tracing::error!("PANIC occurred: {:?}", panic_info);
-        if let Some(location) = panic_info.location() {
-            tracing::error!(
-                "Panic location: {}:{}:{}",
-                location.file(),
-                location.line(),
-                location.column()
-            );
-        }
-        let msg = format!("Panic: {panic_info:?}");
+        let payload = panic_info.payload();
+        let message = payload
+            .downcast_ref::<&'static str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("(non-string panic payload — payload was not &str or String)");
+
+        let location_str = panic_info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "<unknown location>".to_string());
+
+        tracing::error!("PANIC at {}: {}", location_str, message);
+
+        // Sentry capture: include both the message and the location in a single string so the
+        // grouped issue title is readable in the dashboard.
+        let sentry_msg = format!("Panic at {location_str}: {message}");
         let _ = std::panic::catch_unwind(|| {
-            sentry::capture_message(&msg, sentry::Level::Fatal);
+            sentry::capture_message(&sentry_msg, sentry::Level::Fatal);
         });
     }));
 


### PR DESCRIPTION
## Summary

Two changes that turn the-beaconator's startup from "panic at line X, guess what var was bad, redeploy" into "one log dump tells you exactly which env var is broken and why."

### 1. Panic hook prints the actual message
The current hook does `tracing::error!("PANIC occurred: {:?}", panic_info)`, which Debug-prints `PanicHookInfo` whose payload is `Any { .. }` — every `panic!("...")` / `.expect("...")` message is dropped on the floor. Downcasting `payload()` to `&'static str` (string literals) and `String` (formatted) recovers the message and writes it on the same ERROR line.

Before:
```
ERROR PANIC occurred: PanicHookInfo { payload: Any { .. }, location: Location { file: "src/lib.rs", line: 229, column: 10 } }
ERROR Panic location: src/lib.rs:229:10
```

After:
```
ERROR PANIC at src/lib.rs:229:10: Failed to get funding wallet address: Failed to parse private key: invalid string length (got 65, expected 64)
```

### 2. Pre-flight env audit
A new `audit_environment()` runs right after `dotenvy::dotenv()` and walks every env var the service reads. For each one it logs presence + shape *before* any parse happens, so a single boot exposes every config error rather than panicking on the first and hiding the rest.

- **Addresses** (`*_ADDRESS`, `*_FACTORY_ADDRESS`): raw value (public info) + `Address::from_str` pre-validation.
- **Secrets** (`RPC_URL`, `PRIVATE_KEY`, `WALLET_PRIVATE_KEYS`, `BEACONATOR_ACCESS_TOKEN`, `BEACONATOR_ADMIN_TOKEN`, `SENTRY_DSN`, `REDIS_URL`, `SAFE_TX_SERVICE_URL`): only length + a warning if `raw_len != trimmed_len` (the hidden-whitespace footgun we've already hit twice). **Never** the raw value.
- **Plain scalars** (`ENV`, `USDC_TRANSFER_LIMIT`, etc.): the value.
- **Extra checks**: `PRIVATE_KEY` and each entry in `WALLET_PRIVATE_KEYS` get an explicit length-vs-64/66 audit so "this key won't parse" surfaces in the first log dump.

Verbose by design — startup is fatal-by-restart-loop so one extra log block per boot is a cheap price for surfacing every config error in a single pass.

## Why two PRs instead of folding into #58

Per the conversation that prompted this: we've burned multiple deploy cycles on #58 chasing env var typos because the panic message kept landing as `Any { .. }`. Shipping this independently of #58 means the next deploy off `main` (or any other branch) immediately benefits without needing to merge #58 first.

## Test plan

- [x] `make fmt` clean
- [x] `make lint` clean (clippy strict)
- [x] `make test-fast` clean
- [ ] Smoke test on the running deployment: boot with a deliberately bad env var and confirm the audit + panic message both surface in the first log dump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variable audit at startup with detailed validation logging to ensure configuration integrity.

* **Bug Fixes**
  * Improved error messages with human-readable panic details and source location information for easier troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StrobeLabs/the-beaconator/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->