### PR TITLE
Deploy the-beaconator to AWS (perpcity-dev) via SST with Secrets Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,9 @@ dump.rdb
 
 # Generated API clients (generate locally, do not commit)
 clients/
-node_modules/.worktrees
+node_modules/
+.worktrees/
+
+# SST (AWS deployment)
+.sst/
+sst-env.d.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,11 +239,22 @@ Standard recipes define which component factories to call. 12 built-in recipes a
 - 4 Group: dominance, relative_dominance, discrete_allocation, continuous_allocation
 
 ### Redis Storage
-Factory addresses are pre-seeded into Redis (not env vars). Keys:
+Factory addresses are pre-seeded into Redis (not read from env vars at request time). Keys:
 - `beaconator:component_factory:{FactoryType}` - factory config JSON
 - `beaconator:component_factories` - set of factory type names
 - `beaconator:beacon_recipe:{slug}` - recipe config JSON
 - `beaconator:beacon_recipes` - set of recipe slugs
+
+Seeding paths: direct Redis writes (local dev, Railway), or the optional
+`COMPONENT_FACTORIES_JSON` env var — a `{"FactoryType": "0xaddr"}` map seeded at
+startup without overwriting existing entries. The AWS deployment uses the latter
+because ElastiCache is VPC-internal (see `sst.config.ts` and `docs/AWS_DEPLOY.md`).
+
+## AWS deployment (SST)
+`sst.config.ts` deploys the service to ECS Fargate (us-west-2) with Redis
+(ElastiCache Valkey, TLS) and secrets in AWS Secrets Manager, injected by ECS as
+env vars at container start. Stage `testnet` = perpcity-dev account + Arbitrum
+Sepolia. See `docs/AWS_DEPLOY.md` for the secret-creation and deploy runbook.
 
 ### Creation Flow
 1. Look up recipe by slug from RecipeRegistry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ hex = "0.4"
 rocket_okapi = "0.9.0"
 schemars = { version = "0.8", features = ["preserve_order"] }
 
-# Multi-wallet management with Redis
-redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "aio"] }
+# Multi-wallet management with Redis. tokio-rustls-comp enables rediss:// URLs —
+# ElastiCache (the AWS deployment) requires TLS in transit; plain redis:// URLs
+# (local dev, Railway) are unaffected.
+redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "aio", "tokio-rustls-comp"] }
 hostname = "0.4"
 # UUID for instance identification
 uuid = { version = "1.0", features = ["v4"] }

--- a/docs/AWS_DEPLOY.md
+++ b/docs/AWS_DEPLOY.md
@@ -5,21 +5,30 @@ from `sst.config.ts` at the repo root. It follows the same conventions as the ma
 perpcity SST app (perpcity-client): same region, same AWS profiles, same delegated
 `aws.perp.city` Route 53 zone.
 
-Currently configured stage:
+Configured stages:
 
-| Stage     | AWS account                  | Chain                     | URL                                          |
-|-----------|------------------------------|---------------------------|----------------------------------------------|
-| `testnet` | perpcity-dev (267923960054)  | Arbitrum Sepolia (421614) | https://testnet-beaconator.aws.perp.city     |
+| Stage        | AWS account                         | Chain                     | URL                                       |
+|--------------|-------------------------------------|---------------------------|-------------------------------------------|
+| `testnet`    | perpcity-dev (267923960054)         | Arbitrum Sepolia (421614) | https://testnet-beaconator.aws.perp.city  |
+| `production` | perpcity-production (657231015195)  | Arbitrum One (42161)      | https://beaconator.aws.perp.city          |
 
-Mainnet stays on Railway until testnet has soaked; `sst.config.ts` refuses unknown
-stages by design.
+`sst.config.ts` refuses unknown stages by design.
+
+IMPORTANT: deploying `production` is the CUTOVER from Railway. Both run the same
+wallet keys, so two live instances signing concurrently would race nonces. Deploy
+production only when traffic is being moved off the Railway mainnet instance, and
+stop the Railway service promptly after.
+
+Production also needs a one-time DNS setup before its first deploy (see
+"Production DNS zone" below) — the config refuses to deploy until
+`STAGES.production.dnsZone` is filled in.
 
 ## How secrets work
 
 Sensitive values (wallet private keys, the RPC URL, API tokens) live in **AWS Secrets
 Manager**, one secret per variable, named `the-beaconator/<stage>/<VAR>`:
 
-```
+```text
 the-beaconator/testnet/RPC_URL
 the-beaconator/testnet/PRIVATE_KEY
 the-beaconator/testnet/WALLET_PRIVATE_KEYS
@@ -80,10 +89,52 @@ aws secretsmanager create-secret --name "$S/SENTRY_DSN" --secret-string "disable
 unset RPC_URL PRIVATE_KEY WALLET_KEYS ACCESS_TOKEN ADMIN_TOKEN
 ```
 
+For `production`, the same sequence with `AWS_PROFILE=perpcity-production`,
+`S=the-beaconator/production`, and mainnet values (done 2026-06-09). Reusing the
+Railway tokens keeps the backend and scripts working unchanged at cutover.
+
+## Production DNS zone (one-time, before first production deploy)
+
+SST validates ACM certs from a hosted zone in the account it deploys to. The
+production account only has the app/api child zones, so `beaconator.aws.perp.city`
+needs its own delegated child zone, same pattern as the perpcity app:
+
+```bash
+# 1. Create the child zone in perpcity-production; note its Id and NS servers
+AWS_PROFILE=perpcity-production aws route53 create-hosted-zone \
+  --name beaconator.aws.perp.city \
+  --caller-reference "beaconator-$(date +%s)" \
+  --query '{Id:HostedZone.Id,NS:DelegationSet.NameServers}'
+
+# 2. Delegate it from the aws.perp.city zone in perpcity-dev (paste the four NS
+#    values from step 1 into the ResourceRecords list)
+AWS_PROFILE=perpcity-dev aws route53 change-resource-record-sets \
+  --hosted-zone-id Z01504801S59A4HQBX4TS \
+  --change-batch '{
+    "Changes": [{
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "beaconator.aws.perp.city",
+        "Type": "NS",
+        "TTL": 300,
+        "ResourceRecords": [
+          {"Value": "<ns1>"}, {"Value": "<ns2>"}, {"Value": "<ns3>"}, {"Value": "<ns4>"}
+        ]
+      }
+    }]
+  }'
+
+# 3. Fill STAGES.production.dnsZone in sst.config.ts with the zone id from step 1
+#    (the bare id, without the /hostedzone/ prefix)
+```
+
 ## Deploy
 
 ```bash
 AWS_PROFILE=perpcity-dev npx sst deploy --stage testnet
+
+# Production - this is the Railway cutover, see the warning at the top
+AWS_PROFILE=perpcity-production npx sst deploy --stage production
 ```
 
 First deploy takes a while (VPC + NAT + ElastiCache + ACM cert validation + the

--- a/docs/AWS_DEPLOY.md
+++ b/docs/AWS_DEPLOY.md
@@ -1,0 +1,145 @@
+# Deploying the-beaconator to AWS (SST)
+
+The beaconator runs on ECS Fargate in `us-west-2`, deployed with [SST](https://sst.dev)
+from `sst.config.ts` at the repo root. It follows the same conventions as the main
+perpcity SST app (perpcity-client): same region, same AWS profiles, same delegated
+`aws.perp.city` Route 53 zone.
+
+Currently configured stage:
+
+| Stage     | AWS account                  | Chain                     | URL                                          |
+|-----------|------------------------------|---------------------------|----------------------------------------------|
+| `testnet` | perpcity-dev (267923960054)  | Arbitrum Sepolia (421614) | https://testnet-beaconator.aws.perp.city     |
+
+Mainnet stays on Railway until testnet has soaked; `sst.config.ts` refuses unknown
+stages by design.
+
+## How secrets work
+
+Sensitive values (wallet private keys, the RPC URL, API tokens) live in **AWS Secrets
+Manager**, one secret per variable, named `the-beaconator/<stage>/<VAR>`:
+
+```
+the-beaconator/testnet/RPC_URL
+the-beaconator/testnet/PRIVATE_KEY
+the-beaconator/testnet/WALLET_PRIVATE_KEYS
+the-beaconator/testnet/BEACONATOR_ACCESS_TOKEN
+the-beaconator/testnet/BEACONATOR_ADMIN_TOKEN
+the-beaconator/testnet/SENTRY_DSN
+```
+
+ECS injects each value as the matching environment variable when the container
+starts (`valueFrom` in the task definition), so values never appear in the task
+definition, SST state, or this repo. The secrets must exist BEFORE the first deploy
+of a stage: the deploy fails fast at the lookup if one is missing.
+
+Non-secret config (contract addresses, `ENV`, the component-factory map) is plain
+environment configuration in `sst.config.ts`, per stage.
+
+Component factory addresses are passed as `COMPONENT_FACTORIES_JSON` and seeded
+into Redis by the service at startup (existing Redis entries are never
+overwritten). ElastiCache is VPC-internal, so this replaces the by-hand Redis
+seeding used on Railway.
+
+## Prerequisites
+
+- AWS SSO session: `aws sso login --sso-session aws-default`
+- Docker running (the deploy builds the image locally, arm64)
+- `npm install` at the repo root (installs sst)
+- IMPORTANT: a shell-exported `AWS_PROFILE` overrides the profile in
+  `sst.config.ts`. Prefix commands with `AWS_PROFILE=perpcity-dev` (as shown
+  below) or unset it.
+
+## One-time per stage: create the secrets
+
+Run in a terminal with SSO logged in. `read -rs` keeps values out of shell history.
+
+```bash
+export AWS_PROFILE=perpcity-dev AWS_REGION=us-west-2
+S=the-beaconator/testnet
+
+read -rs RPC_URL          # full RPC URL with API key, e.g. https://arb-sepolia.g.alchemy.com/v2/...
+aws secretsmanager create-secret --name "$S/RPC_URL" --secret-string "$RPC_URL"
+
+read -rs PRIVATE_KEY      # funding wallet key, no 0x prefix
+aws secretsmanager create-secret --name "$S/PRIVATE_KEY" --secret-string "$PRIVATE_KEY"
+
+read -rs WALLET_KEYS      # comma-separated pool keys, no 0x prefix
+aws secretsmanager create-secret --name "$S/WALLET_PRIVATE_KEYS" --secret-string "$WALLET_KEYS"
+
+read -rs ACCESS_TOKEN
+aws secretsmanager create-secret --name "$S/BEACONATOR_ACCESS_TOKEN" --secret-string "$ACCESS_TOKEN"
+
+read -rs ADMIN_TOKEN
+aws secretsmanager create-secret --name "$S/BEACONATOR_ADMIN_TOKEN" --secret-string "$ADMIN_TOKEN"
+
+# Real DSN if there is a testnet Sentry project; the literal string "disabled"
+# otherwise (the service logs a warning and runs without Sentry).
+aws secretsmanager create-secret --name "$S/SENTRY_DSN" --secret-string "disabled"
+
+unset RPC_URL PRIVATE_KEY WALLET_KEYS ACCESS_TOKEN ADMIN_TOKEN
+```
+
+## Deploy
+
+```bash
+AWS_PROFILE=perpcity-dev npx sst deploy --stage testnet
+```
+
+First deploy takes a while (VPC + NAT + ElastiCache + ACM cert validation + the
+Rust release build). Subsequent deploys only rebuild the image and roll the
+service.
+
+To preview changes without applying: `AWS_PROFILE=perpcity-dev npx sst diff --stage testnet`
+
+## Verify
+
+```bash
+# Health / endpoint list (unauthenticated)
+curl -s https://testnet-beaconator.aws.perp.city/ | head
+
+# Component factories seeded from COMPONENT_FACTORIES_JSON (authenticated)
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+  https://testnet-beaconator.aws.perp.city/component_factories
+```
+
+Logs land in a CloudWatch log group under `/sst/cluster/` in us-west-2:
+
+```bash
+export AWS_PROFILE=perpcity-dev AWS_REGION=us-west-2
+LOG_GROUP=$(aws logs describe-log-groups \
+  --query 'logGroups[?contains(logGroupName, `Beaconator`)].logGroupName' --output text)
+aws logs tail --follow "$LOG_GROUP"
+```
+
+## Rotate a secret
+
+```bash
+export AWS_PROFILE=perpcity-dev AWS_REGION=us-west-2
+read -rs NEW_VALUE
+aws secretsmanager put-secret-value --secret-id the-beaconator/testnet/PRIVATE_KEY --secret-string "$NEW_VALUE"
+unset NEW_VALUE
+```
+
+ECS reads secrets at container start, so roll the service to pick up the new value:
+
+```bash
+AWS_PROFILE=perpcity-dev aws ecs update-service --force-new-deployment --region us-west-2 \
+  --cluster $(AWS_PROFILE=perpcity-dev aws ecs list-clusters --region us-west-2 --query 'clusterArns[?contains(@, `the-beaconator-testnet`)]' --output text) \
+  --service $(AWS_PROFILE=perpcity-dev aws ecs list-services --region us-west-2 --cluster $(AWS_PROFILE=perpcity-dev aws ecs list-clusters --region us-west-2 --query 'clusterArns[?contains(@, `the-beaconator-testnet`)]' --output text) --query 'serviceArns[0]' --output text)
+```
+
+(or just `npx sst deploy --stage testnet` again).
+
+## Tear down a stage
+
+```bash
+AWS_PROFILE=perpcity-dev npx sst remove --stage testnet
+```
+
+Secrets Manager secrets are not managed by SST and survive a remove; delete them
+explicitly if you mean it:
+
+```bash
+aws secretsmanager delete-secret --secret-id the-beaconator/testnet/PRIVATE_KEY --recovery-window-in-days 7
+```

--- a/env.example
+++ b/env.example
@@ -71,3 +71,9 @@ PRICING_MODULE_ADDRESS=0x5678901234567890123456789012345678901234
 # Not used by the deploy / open flows.
 # PROTOCOL_FEE_MANAGER_ADDRESS=0x6789012345678901234567890123456789012345
 # MODULE_REGISTRY_ADDRESS=0x789012345678901234567890123456789012345a
+
+# Optional: JSON map of component factory addresses seeded into Redis at startup.
+# Existing Redis entries are never overwritten. Set by the AWS deployment (see
+# sst.config.ts / docs/AWS_DEPLOY.md) where Redis is VPC-internal; local dev and
+# Railway can keep seeding Redis directly instead.
+# COMPONENT_FACTORIES_JSON={"CGBMFactory":"0x...","StandaloneBeaconFactory":"0x..."}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,836 @@
+{
+  "name": "the-beaconator-infra",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "the-beaconator-infra",
+      "dependencies": {
+        "sst": "^4.15.2"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1064.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1064.0.tgz",
+      "integrity": "sha512-yKgtZ27nNDqcq7Kq0mr9XagoAtNX+Hyb0z/ryH1fTQseXPRBxbHyukn8JYY5FwqknkNdMmagwFM8nsCe3CwI7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/credential-provider-node": "^3.972.53",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.19.tgz",
+      "integrity": "sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.45.tgz",
+      "integrity": "sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.47.tgz",
+      "integrity": "sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.51.tgz",
+      "integrity": "sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/credential-provider-env": "^3.972.45",
+        "@aws-sdk/credential-provider-http": "^3.972.47",
+        "@aws-sdk/credential-provider-login": "^3.972.50",
+        "@aws-sdk/credential-provider-process": "^3.972.45",
+        "@aws-sdk/credential-provider-sso": "^3.972.50",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.50.tgz",
+      "integrity": "sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.53.tgz",
+      "integrity": "sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.45",
+        "@aws-sdk/credential-provider-http": "^3.972.47",
+        "@aws-sdk/credential-provider-ini": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.45",
+        "@aws-sdk/credential-provider-sso": "^3.972.50",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.45.tgz",
+      "integrity": "sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.50.tgz",
+      "integrity": "sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/token-providers": "3.1064.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.50.tgz",
+      "integrity": "sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.18.tgz",
+      "integrity": "sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
+      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1064.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1064.0.tgz",
+      "integrity": "sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/durable-execution-sdk-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws/durable-execution-sdk-js/-/durable-execution-sdk-js-1.0.2.tgz",
+      "integrity": "sha512-KIYBVqV9gArkWdPEDYOjJqLlO+NecmCXOXadNBlOspJTmqztwuiyb6aZc468bYWSGuL4Me/gyTIK97ubkwFNCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-lambda": "^3.943.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.18.tgz",
+      "integrity": "sha512-3Cf+YaUl07p24MoQ46rFwulAmiyCwH2+1zw1ZyPAX5OtJ34Hh185DwB8y/qRLb6cYYYtSFJ9pthyLc0MD4e8sQ==",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+      "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
+      "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.4.tgz",
+      "integrity": "sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst/-/sst-4.15.2.tgz",
+      "integrity": "sha512-PJX4rVQ66g1NgzWucm+Zelv0S5/hhqT5DkedKPb6IZSxyLz0R5r9hI2xO5ITS9hSY8IdUeJl1WMMca8f3vNd9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws/durable-execution-sdk-js": "1.0.2",
+        "aws4fetch": "1.0.18",
+        "jose": "5.2.3",
+        "openid-client": "5.6.4"
+      },
+      "bin": {
+        "sst": "bin/sst.mjs"
+      },
+      "optionalDependencies": {
+        "sst-darwin-arm64": "4.15.2",
+        "sst-darwin-x64": "4.15.2",
+        "sst-linux-arm64": "4.15.2",
+        "sst-linux-x64": "4.15.2",
+        "sst-linux-x86": "4.15.2",
+        "sst-win32-arm64": "4.15.2",
+        "sst-win32-x64": "4.15.2",
+        "sst-win32-x86": "4.15.2"
+      }
+    },
+    "node_modules/sst-darwin-arm64": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-darwin-arm64/-/sst-darwin-arm64-4.15.2.tgz",
+      "integrity": "sha512-jTOaR9+tCOQoEDcPL0i59Zf5nmPv3C91Lt2wvikyBnq+Zibpen1zsQaQ3S3v5R0MAH+AqlBMBkXx3vD9dVve0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sst-darwin-x64": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-darwin-x64/-/sst-darwin-x64-4.15.2.tgz",
+      "integrity": "sha512-KZ/DJBdN3kDnNSXr7hPeR10dnCNpSLaIn1gjXvXO/rgMeawfaaPA74zU1Su0yjA47fbIC3nH5TT2+S/6vFZD+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sst-linux-arm64": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-linux-arm64/-/sst-linux-arm64-4.15.2.tgz",
+      "integrity": "sha512-zT1+suSr5DRCTTPVUo8LmJjXnFxXj49CRRMoGnBq4QBeeyzOaw/L3uwZ4GDn91+s7kGRMpykhsSPBgplBETM8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sst-linux-x64": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-linux-x64/-/sst-linux-x64-4.15.2.tgz",
+      "integrity": "sha512-Da7FI3ziaTfLsWx/vTuUPlSDfNIF2LHuEPugp/Y4w5pBTJ3cYbBhMhPC6KnXI46itvOfDYHdsFdVrDKJ8dpEsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sst-linux-x86": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-linux-x86/-/sst-linux-x86-4.15.2.tgz",
+      "integrity": "sha512-ZzJPul4U++Cg/UJmJVSUV0ndMbcImUbnqwxYhf5EaQLaO+se6AX52uIZBlQTxIQ6rrnHAq5Kw7WUWur7A/BZQA==",
+      "cpu": [
+        "x86"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sst-win32-arm64": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-win32-arm64/-/sst-win32-arm64-4.15.2.tgz",
+      "integrity": "sha512-DrovhJEZgo+W9s/AL1CdBeqdyG9nu8e8N7S5yxYFgoPJVti6mBDBZKY9HjYjkHXBYOPw6slcdHlh64DqDRzI9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/sst-win32-x64": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-win32-x64/-/sst-win32-x64-4.15.2.tgz",
+      "integrity": "sha512-tywny4cRVFJUAHGsSxeIH2p/4AEigJks5UjC0HuP0kr/AyWeuCHglXsdf4JGMxSrHY6phdcSLUqhPKruZsjOwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/sst-win32-x86": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/sst-win32-x86/-/sst-win32-x86-4.15.2.tgz",
+      "integrity": "sha512-p3TKMSP8t6K+h54dZB/AAu1LTkhjZ4Zn+h5x4nTzpAery7VzBxYseA/9F/DnAbck0pfHRsu3TBYtyHJsvCFJ0A==",
+      "cpu": [
+        "x86"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "the-beaconator-infra",
+  "private": true,
+  "description": "SST deployment for the-beaconator (AWS ECS Fargate). See docs/AWS_DEPLOY.md.",
+  "scripts": {
+    "deploy:testnet": "sst deploy --stage testnet",
+    "diff:testnet": "sst diff --stage testnet",
+    "remove:testnet": "sst remove --stage testnet"
+  },
+  "dependencies": {
+    "sst": "^4.15.2"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,9 @@ fn audit_environment() {
         "ETH_TRANSFER_LIMIT",
         "BEACONATOR_INSTANCE_ID",
         "RUST_LOG",
+        // JSON map of component factory addresses seeded into Redis at startup
+        // (set by the AWS deployment; see sst.config.ts)
+        "COMPONENT_FACTORIES_JSON",
     ];
 
     let mut problems = 0usize;
@@ -613,6 +616,27 @@ pub async fn create_rocket() -> Rocket<Build> {
         .unwrap_or_else(|e| {
             panic!("ComponentFactoryRegistry failed to initialize: {e}. Check Redis connectivity.")
         });
+
+    // Seed factory addresses from COMPONENT_FACTORIES_JSON when provided (the AWS
+    // deployment sets it because ElastiCache is VPC-internal and cannot be seeded by
+    // hand the way the Railway Redis was). Existing entries are never overwritten, so
+    // re-deploys and registry edits made through Redis stay intact.
+    if let Ok(factories_json) = env::var("COMPONENT_FACTORIES_JSON") {
+        let configs = models::component_factory::parse_component_factories_json(&factories_json)
+            .unwrap_or_else(|e| panic!("COMPONENT_FACTORIES_JSON is invalid: {e}"));
+        match component_factory_registry.seed_defaults(&configs).await {
+            Ok(result) => {
+                tracing::info!(
+                    "Component factory seed: {} seeded, {} already existed",
+                    result.seeded,
+                    result.skipped
+                );
+            }
+            Err(e) => {
+                panic!("Failed to seed component factories from COMPONENT_FACTORIES_JSON: {e}");
+            }
+        }
+    }
 
     match component_factory_registry.list_factories().await {
         Ok(factories) => {

--- a/src/models/component_factory.rs
+++ b/src/models/component_factory.rs
@@ -65,6 +65,33 @@ pub struct ComponentFactoryConfig {
     pub enabled: bool,
 }
 
+/// Parse a `{"FactoryType": "0xaddress", ...}` JSON map (the COMPONENT_FACTORIES_JSON
+/// env var set by the AWS deployment) into enabled factory configs for seeding.
+///
+/// Errors on malformed JSON, unknown factory type names, and unparseable addresses —
+/// a deployment with a bad map should fail loudly at startup, not half-seed.
+pub fn parse_component_factories_json(json: &str) -> Result<Vec<ComponentFactoryConfig>, String> {
+    use std::collections::BTreeMap;
+    use std::str::FromStr;
+
+    let map: BTreeMap<String, String> = serde_json::from_str(json)
+        .map_err(|e| format!("COMPONENT_FACTORIES_JSON is not a JSON string map: {e}"))?;
+
+    map.into_iter()
+        .map(|(type_name, addr)| {
+            let factory_type = ComponentFactoryType::from_str_name(&type_name)
+                .ok_or_else(|| format!("Unknown component factory type '{type_name}'"))?;
+            let address = Address::from_str(addr.trim())
+                .map_err(|e| format!("Invalid address for component factory '{type_name}': {e}"))?;
+            Ok(ComponentFactoryConfig {
+                factory_type,
+                address,
+                enabled: true,
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,5 +122,45 @@ mod tests {
             ComponentFactoryType::StandaloneBeaconFactory
         );
         assert!(deser.enabled);
+    }
+
+    #[test]
+    fn test_parse_component_factories_json() {
+        let json = r#"{
+            "CGBMFactory": "0x569AF5De8f8815a662aD4dffC6391b70ADFA9C2A",
+            "ECDSAVerifierFactory": "0x47978f1AB8911064B2979aB0e9E90152c1d916c0"
+        }"#;
+        let configs = parse_component_factories_json(json).unwrap();
+        assert_eq!(configs.len(), 2);
+        assert!(configs.iter().all(|c| c.enabled));
+        let cgbm = configs
+            .iter()
+            .find(|c| c.factory_type == ComponentFactoryType::CGBMFactory)
+            .unwrap();
+        assert_eq!(
+            cgbm.address,
+            address!("0x569AF5De8f8815a662aD4dffC6391b70ADFA9C2A")
+        );
+    }
+
+    #[test]
+    fn test_parse_component_factories_json_rejects_unknown_type() {
+        let err = parse_component_factories_json(
+            r#"{"NotAFactory": "0x0000000000000000000000000000000000000001"}"#,
+        )
+        .unwrap_err();
+        assert!(err.contains("Unknown component factory type 'NotAFactory'"));
+    }
+
+    #[test]
+    fn test_parse_component_factories_json_rejects_bad_address() {
+        let err = parse_component_factories_json(r#"{"CGBMFactory": "0x123"}"#).unwrap_err();
+        assert!(err.contains("Invalid address for component factory 'CGBMFactory'"));
+    }
+
+    #[test]
+    fn test_parse_component_factories_json_rejects_malformed_json() {
+        let err = parse_component_factories_json("not json").unwrap_err();
+        assert!(err.contains("not a JSON string map"));
     }
 }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,0 +1,250 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+/**
+ * the-beaconator on AWS — ECS Fargate via SST, mirroring the conventions of the
+ * main perpcity SST app (perpcity-client/sst.config.ts): same region (us-west-2),
+ * same AWS profiles, same Cluster/Service/Redis shapes, same delegated
+ * aws.perp.city Route 53 zone for HTTPS.
+ *
+ * Differences from the perpcity app, and why:
+ *
+ *  1. Secrets live in AWS Secrets Manager, NOT `sst.Secret`. The beaconator holds
+ *     wallet PRIVATE KEYS; Secrets Manager gives KMS encryption at rest, IAM-scoped
+ *     reads, an audit trail, and rotation — none of which the SST state-bucket
+ *     secrets provide. Values are injected by ECS at container start via
+ *     `valueFrom` (the `ssm` prop below), so they never appear in the task
+ *     definition, the SST state, or this file. Secrets must be created BEFORE the
+ *     first deploy of a stage (see docs/AWS_DEPLOY.md for the exact commands):
+ *       the-beaconator/<stage>/RPC_URL
+ *       the-beaconator/<stage>/PRIVATE_KEY
+ *       the-beaconator/<stage>/WALLET_PRIVATE_KEYS
+ *       the-beaconator/<stage>/BEACONATOR_ACCESS_TOKEN
+ *       the-beaconator/<stage>/BEACONATOR_ADMIN_TOKEN
+ *       the-beaconator/<stage>/SENTRY_DSN          (value may be empty)
+ *
+ *  2. Own VPC + own Redis, no coupling to the perpcity app's stacks. The only
+ *     consumer (perpcity-app-backend) talks to the beaconator over its public
+ *     HTTPS domain with a bearer token, exactly as it did on Railway, so nothing
+ *     needs VPC-level reachability. Default 10.0/16 CIDR is fine: this VPC is
+ *     never peered (the Tiger Cloud peering constraint in the perpcity app does
+ *     not apply here).
+ *
+ *  3. Component factory addresses ship as COMPONENT_FACTORIES_JSON and are seeded
+ *     into Redis by the service at startup (src/lib.rs). On Railway this seeding
+ *     was done by hand against a publicly reachable Redis; ElastiCache is
+ *     VPC-internal, so the seed has to ride in with the app.
+ *
+ * Stage → account/chain:
+ *   testnet → perpcity-dev (267923960054), Arbitrum Sepolia (ENV=testnet),
+ *             domain testnet-beaconator.aws.perp.city
+ *   production is intentionally NOT configured yet — mainnet stays on Railway
+ *   until testnet has soaked. The stage guard below makes this explicit.
+ */
+export default $config({
+  app(input) {
+    return {
+      name: "the-beaconator",
+      home: "aws",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      protect: input?.stage === "production",
+      providers: {
+        aws: {
+          region: "us-west-2",
+          profile:
+            input?.stage === "production"
+              ? "perpcity-production"
+              : "perpcity-dev",
+        },
+      },
+    };
+  },
+  async run() {
+    // Per-stage chain config. Only testnet (Arbitrum Sepolia) is wired up; add a
+    // production entry here when mainnet cuts over from Railway. Addresses are
+    // the 2026-06 Arbitrum Sepolia deployment of beacons@v0.0.1 +
+    // perpcity-contracts@v0.1.0 (the tags pinned in .contracts-versions).
+    const STAGES: Record<
+      string,
+      {
+        env: "mainnet" | "testnet";
+        domain: string;
+        dnsZone: string;
+        addresses: Record<string, string>;
+        componentFactories: Record<string, string>;
+      }
+    > = {
+      testnet: {
+        env: "testnet",
+        // Delegated child zone aws.perp.city lives in perpcity-dev; SST manages
+        // the record + ACM cert from it (same zone the perpcity app uses).
+        domain: "testnet-beaconator.aws.perp.city",
+        dnsZone: "Z01504801S59A4HQBX4TS",
+        addresses: {
+          // beacons@v0.0.1 (Arbitrum Sepolia). Registry address cross-checked
+          // against perpcity-indexer/config/arbitrum-sepolia.json and on-chain
+          // (owner matches moduleRegistry/protocolFeeManager, created at the
+          // indexer's startBlock).
+          PERPCITY_REGISTRY_ADDRESS: "0xAA0B2AB577D75bC8ED5380752b612a04896d6f10",
+          ECDSA_VERIFIER_FACTORY_ADDRESS:
+            "0x47978f1AB8911064B2979aB0e9E90152c1d916c0",
+          // perpcity-contracts@v0.1.0 (Arbitrum Sepolia)
+          PERP_FACTORY_ADDRESS: "0xa54F81e7BD5C0d52d6fdE2ba40d0B1123d53E7a7",
+          FEES_MODULE_ADDRESS: "0xa8f7453Fc54E4578dDde12e3DC65b7614938a620",
+          FUNDING_MODULE_ADDRESS: "0x693852A74cF7f5936e1cfD6f3971aE3027b84e7D",
+          MARGIN_RATIOS_MODULE_ADDRESS:
+            "0xB118b54e8b513F6A67fD555348f216d804C0eB89",
+          PRICE_IMPACT_MODULE_ADDRESS:
+            "0x0168716E60f5A54e62aec8c20D3caa37e5ce61C2",
+          PRICING_MODULE_ADDRESS: "0xc33205B471a9529fdD0A81fdEA037737Ff5c7A97",
+          USDC_ADDRESS: "0xBEF280BefeE2Cb28c20D1E4Cc1da999B4DA0f1fD",
+          MODULE_REGISTRY_ADDRESS:
+            "0xA8559d9Fb429D184CD06EfDF2A0F16C4a19Bb654",
+          PROTOCOL_FEE_MANAGER_ADDRESS:
+            "0x5bA2AbaD153bbCAe38638A51e61ea2D11CAC8D9B",
+          // Canonical Multicall3, same address on every chain.
+          MULTICALL3_ADDRESS: "0xcA11bde05977b3631167028862bE2a173976CA11",
+        },
+        // Seeded into Redis at startup (keys the modular-beacon recipes resolve
+        // against). Names must match ComponentFactoryType variants in
+        // src/models/component_factory.rs — note WeightedSumComponentFactory is
+        // the deployment artifact called "WeightedSumFactory".
+        componentFactories: {
+          IdentityBeaconFactory: "0x17242F60f44f084Bb56c6Dcbd343Be9236185272",
+          StandaloneBeaconFactory: "0x8097Bc34eDD7dA12f70dC1521244ace78080CCb4",
+          CompositeBeaconFactory: "0xCAaE988b0bd3DD5Ab752764A75d96D4079B72263",
+          GroupManagerFactory: "0x20B2B2DE4811b88f627447c3ed19A0565FFbF98D",
+          IdentityPreprocessorFactory:
+            "0x7d9DcBFD7517E4D33eFca2ACe2a0271D6EBb091E",
+          ThresholdFactory: "0x371f649502d813728D58A934eE828d6B603a1d94",
+          TernaryToBinaryFactory: "0x038180774642e95a78Cfb8ac77301Cb3A42458BD",
+          ArgmaxFactory: "0xBc0F014d2d1781E22880E334066563C4c215C94d",
+          CGBMFactory: "0x569AF5De8f8815a662aD4dffC6391b70ADFA9C2A",
+          DGBMFactory: "0xf654c64faf8261D25b33CA8Ae3e605C5b4109AE8",
+          BoundedFactory: "0x39BCC1c71f7255b993F09ECffd94f1410531210E",
+          UnboundedFactory: "0x50b217ECBe804a950F5a4E9B22D877927B777548",
+          WeightedSumComponentFactory:
+            "0xeD221d2d6a96abf2E5D4D07783564A7dF7aEa8CD",
+          DominanceFactory: "0x2927B0d72fd6C61762FCd4193943f31a12cEdb4A",
+          RelativeDominanceFactory:
+            "0x94595171ad68b00C6F0dcbbfFb790dE8869fd14B",
+          ContinuousAllocationFactory:
+            "0x746cc8Ce1a56D98dce0569bFcC4a52d754E9F9B6",
+          DiscreteAllocationFactory:
+            "0x63B2A3aE73570bD6369198Ce7f02aD55D6F3990c",
+          SoftmaxFactory: "0xcc01D3B3A2648FF1D0F8E4cd8E5931211A472296",
+          GMNormalizeFactory: "0x5Ae6Ad8b345B2371026f17f87F4Ef0C66ea5dB57",
+          ECDSAVerifierFactory: "0x47978f1AB8911064B2979aB0e9E90152c1d916c0",
+        },
+      },
+    };
+
+    const stage = STAGES[$app.stage];
+    if (!stage) {
+      throw new Error(
+        `Stage "${$app.stage}" is not configured. Known stages: ${Object.keys(
+          STAGES,
+        ).join(", ")}. Add a chain-config entry to STAGES in sst.config.ts ` +
+          `(and create its Secrets Manager secrets) before deploying.`,
+      );
+    }
+
+    // fck-nat EC2 NAT (not a managed gateway): egress is only ECR pulls + chain
+    // RPC calls, and this is a non-prod stage — same call the perpcity app made.
+    const vpc = new sst.aws.Vpc("Vpc", { nat: "ec2" });
+
+    // Wallet pool locks + the component-factory/recipe registries. Single-node
+    // Valkey (t4g.micro), matching the service's non-cluster Redis client.
+    // ElastiCache enables TLS + auth by default, hence the rediss:// URL below
+    // and the tokio-rustls-comp feature on the redis crate in Cargo.toml.
+    const redis = new sst.aws.Redis("Redis", {
+      vpc,
+      engine: "valkey",
+      cluster: false,
+      // Same gotcha the perpcity app hit: SST writes a `cluster-enabled`
+      // parameter that AWS rejects when creating a FRESH Valkey parameter group.
+      // This stage's group is created from scratch, so strip the parameter.
+      transform: {
+        parameterGroup: (args) => {
+          args.parameters = [];
+        },
+      },
+    });
+    const redisUrl = $interpolate`rediss://${redis.username}:${redis.password}@${redis.host}:${redis.port}`;
+
+    // Pre-created Secrets Manager secrets (see header). getSecretOutput fails the
+    // deploy with a clear error if one is missing — intentional: secrets first,
+    // deploy second.
+    const secretNames = [
+      "RPC_URL",
+      "PRIVATE_KEY",
+      "WALLET_PRIVATE_KEYS",
+      "BEACONATOR_ACCESS_TOKEN",
+      "BEACONATOR_ADMIN_TOKEN",
+      "SENTRY_DSN",
+    ] as const;
+    const secretArns = Object.fromEntries(
+      secretNames.map((name) => [
+        name,
+        aws.secretsmanager.getSecretOutput({
+          name: `the-beaconator/${$app.stage}/${name}`,
+        }).arn,
+      ]),
+    );
+
+    const cluster = new sst.aws.Cluster("Cluster", { vpc });
+
+    const service = new sst.aws.Service("Beaconator", {
+      cluster,
+      image: { context: "." },
+      // Fargate Graviton; the Dockerfile is arch-agnostic (rust:bookworm +
+      // debian:bookworm-slim) and builds natively on Apple Silicon.
+      architecture: "arm64",
+      cpu: "0.5 vCPU",
+      memory: "1 GB",
+      // Spot is fine here: writes are short-lived txs, wallet locks expire (60s
+      // TTL), and every operation is retryable by the caller. Revisit for a
+      // production stage.
+      capacity: "spot",
+      // Exactly one task: the wallet pool serializes writes through Redis locks
+      // either way, and one instance keeps tx nonce behavior simple.
+      scaling: { min: 1, max: 1 },
+      logging: { retention: "1 month" },
+      // ECS injects each secret's value as the named env var at container start
+      // (task execution role reads them; SST wires that IAM up from `ssm`).
+      ssm: secretArns,
+      loadBalancer: {
+        domain: {
+          name: stage.domain,
+          dns: sst.aws.dns({ zone: stage.dnsZone }),
+        },
+        rules: [
+          { listen: "443/https", forward: "8000/http" },
+          { listen: "80/http", redirect: "443/https" },
+        ],
+        // GET / is unauthenticated and returns 200 once Rocket is up (it only
+        // reports endpoint info); the container has no curl, so the ALB check
+        // is the health check.
+        health: {
+          "8000/http": { path: "/", interval: "30 seconds" },
+        },
+      },
+      environment: {
+        // testnet => Arbitrum Sepolia (chain id 421614) inside the service.
+        ENV: stage.env,
+        PORT: "8000",
+        REDIS_URL: redisUrl,
+        RUST_LOG: "info,the_beaconator=info,rocket=warn",
+        BEACONATOR_INSTANCE_ID: `aws-${$app.stage}`,
+        COMPONENT_FACTORIES_JSON: JSON.stringify(stage.componentFactories),
+        ...stage.addresses,
+      },
+    });
+
+    return {
+      url: `https://${stage.domain}`,
+      loadBalancer: service.url,
+      redisHost: redis.host,
+      vpc: vpc.id,
+    };
+  },
+});

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -35,10 +35,13 @@
  *     VPC-internal, so the seed has to ride in with the app.
  *
  * Stage → account/chain:
- *   testnet → perpcity-dev (267923960054), Arbitrum Sepolia (ENV=testnet),
- *             domain testnet-beaconator.aws.perp.city
- *   production is intentionally NOT configured yet — mainnet stays on Railway
- *   until testnet has soaked. The stage guard below makes this explicit.
+ *   testnet    → perpcity-dev (267923960054), Arbitrum Sepolia (ENV=testnet),
+ *                domain testnet-beaconator.aws.perp.city
+ *   production → perpcity-production (657231015195), Arbitrum One (ENV=mainnet),
+ *                domain beaconator.aws.perp.city. Config is wired but DEPLOYING
+ *                IT IS THE CUTOVER from Railway: both run the same wallet keys,
+ *                so two live instances signing concurrently would race nonces.
+ *                Deploy production only when traffic is being moved off Railway.
  */
 export default $config({
   app(input) {
@@ -59,10 +62,11 @@ export default $config({
     };
   },
   async run() {
-    // Per-stage chain config. Only testnet (Arbitrum Sepolia) is wired up; add a
-    // production entry here when mainnet cuts over from Railway. Addresses are
-    // the 2026-06 Arbitrum Sepolia deployment of beacons@v0.0.1 +
-    // perpcity-contracts@v0.1.0 (the tags pinned in .contracts-versions).
+    // Per-stage chain config. Addresses are the deployments of beacons@v0.0.1 +
+    // perpcity-contracts@v0.1.0 (the tags pinned in .contracts-versions) on each
+    // chain. Mainnet factory addresses were verified byte-for-byte identical to
+    // the Sepolia deployments (same deployer, nonces 0-19, exact runtime
+    // bytecode including metadata hash) and against the official address list.
     const STAGES: Record<
       string,
       {
@@ -71,6 +75,8 @@ export default $config({
         dnsZone: string;
         addresses: Record<string, string>;
         componentFactories: Record<string, string>;
+        // Stage-specific plain env overrides (e.g. transfer limits).
+        extraEnvironment?: Record<string, string>;
       }
     > = {
       testnet: {
@@ -136,6 +142,77 @@ export default $config({
           ECDSAVerifierFactory: "0x47978f1AB8911064B2979aB0e9E90152c1d916c0",
         },
       },
+      production: {
+        env: "mainnet",
+        // Needs a beaconator.aws.perp.city hosted zone in perpcity-production,
+        // delegated from the aws.perp.city zone in perpcity-dev (the same
+        // pattern as the perpcity app's app/api.aws.perp.city child zones).
+        // Fill dnsZone with the new zone id once it exists; the guard below
+        // refuses to deploy production until then. Zone creation commands are
+        // in docs/AWS_DEPLOY.md.
+        domain: "beaconator.aws.perp.city",
+        dnsZone: "",
+        addresses: {
+          // beacons@v0.0.1 (Arbitrum One). Same values as the working Railway
+          // mainnet instance and perpcity-indexer/config/arbitrum-mainnet.json.
+          PERPCITY_REGISTRY_ADDRESS: "0xBEF280BefeE2Cb28c20D1E4Cc1da999B4DA0f1fD",
+          ECDSA_VERIFIER_FACTORY_ADDRESS:
+            "0x687EeB3E4989441C91BF0D4F797AF4C400803c95",
+          // perpcity-contracts@v0.1.0 (Arbitrum One)
+          PERP_FACTORY_ADDRESS: "0xCE0c5f65A5eDa69A1dFb3f3273749B649abc4eC6",
+          FEES_MODULE_ADDRESS: "0xBfda8AA80132C51995B37c03D9FE384dcbF0056E",
+          FUNDING_MODULE_ADDRESS: "0xB9572a6CdD39965e2d03F13d5559e0CA9fe599D1",
+          MARGIN_RATIOS_MODULE_ADDRESS:
+            "0x8Afca53c52B1F02d76aefB811C6B08F4BD3e4cf9",
+          PRICE_IMPACT_MODULE_ADDRESS:
+            "0x71889d6B403DdC5007d1EBaBB52D1fcd5ec04832",
+          PRICING_MODULE_ADDRESS: "0xF4689DA0CaC3f23a04145236Dbfe81C3c58cFe22",
+          // Canonical Arbitrum One USDC (Circle), not a mock.
+          USDC_ADDRESS: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          MODULE_REGISTRY_ADDRESS:
+            "0xa8D623C214F70A6D40Cad299d1fffF9667a97965",
+          PROTOCOL_FEE_MANAGER_ADDRESS:
+            "0x9d0bB98fca4D4913C3851606941B52DDfdB4b9EE",
+          MULTICALL3_ADDRESS: "0xcA11bde05977b3631167028862bE2a173976CA11",
+          // Strobe Safe multisig (beacon registration goes through the Safe on
+          // mainnet; testnet registers directly).
+          SAFE_ADDRESS: "0x2D0be18386297d833E63d0B1F6bc93F391aF6F93",
+        },
+        // Same contracts as Sepolia, byte-for-byte (verified): deployer
+        // 0x91e8a9D4...B1, creation nonces 0-19 on both chains.
+        componentFactories: {
+          IdentityBeaconFactory: "0xa9f0A69112b83621b0922Cb321f7B0263Ea4273A",
+          StandaloneBeaconFactory: "0xAa96040DC6C0Bf47702c2131F0E03B2386d7A70C",
+          CompositeBeaconFactory: "0xb8B5eFBb29eD832a99dB2D4D3dfa0b1B668D1dA3",
+          GroupManagerFactory: "0xb98FF5583E57595B50AD20bc910FfCDE10C40d0e",
+          IdentityPreprocessorFactory:
+            "0x90bE3B12FC821470eC3a8e03067E556d87d309A2",
+          ThresholdFactory: "0xF7Bb7fAa37C325374b341bEFD9fC13A6efd37e88",
+          TernaryToBinaryFactory: "0x87879e7726D9D16397eaF4E316E2EBd333475EC2",
+          ArgmaxFactory: "0xFc149D2F0BE9432E79fe2FA376310444Bf23A857",
+          CGBMFactory: "0x656CDc258f8EF7206e16dCB382082D5249a15d46",
+          DGBMFactory: "0x7Dc0686DAb43AC6B7F3999952b795c555509a155",
+          BoundedFactory: "0x77b1049546620B54C810424483c855Ba8385dED7",
+          UnboundedFactory: "0xEBaC70fdD7A734177D2569743FDcA08b0c6F1012",
+          WeightedSumComponentFactory:
+            "0x36a6B3EC337C67F7da4C5f07b24F4Ff954FA3983",
+          DominanceFactory: "0x1E1D015e2d8feF63bB0641E5505027173A4Ca8B3",
+          RelativeDominanceFactory:
+            "0x05C0023b323138d5353018A1C350274932B8E9F6",
+          ContinuousAllocationFactory:
+            "0x9Af8aC20D0F643Ca1d50C9B4c5D36EA1B32943b9",
+          DiscreteAllocationFactory:
+            "0x468b76cF392209DE9569dFA30A6a6e944AD78b9C",
+          SoftmaxFactory: "0x1F9a978468461c9B582F2e09e98fEbdB57d85158",
+          GMNormalizeFactory: "0xE04Aa90DC32BEf1f56Ce9A8ED2AcE3C571438E30",
+          ECDSAVerifierFactory: "0x687EeB3E4989441C91BF0D4F797AF4C400803c95",
+        },
+        // The live mainnet instance disables guest-wallet funding entirely.
+        extraEnvironment: {
+          USDC_TRANSFER_LIMIT: "0",
+          ETH_TRANSFER_LIMIT: "0",
+        },
+      },
     };
 
     const stage = STAGES[$app.stage];
@@ -147,10 +224,18 @@ export default $config({
           `(and create its Secrets Manager secrets) before deploying.`,
       );
     }
+    if (!stage.dnsZone) {
+      throw new Error(
+        `Stage "${$app.stage}" has no dnsZone configured. Create the hosted ` +
+          `zone for ${stage.domain} (plus its NS delegation) and fill ` +
+          `STAGES.${$app.stage}.dnsZone in sst.config.ts — see docs/AWS_DEPLOY.md.`,
+      );
+    }
+    const isProd = $app.stage === "production";
 
-    // fck-nat EC2 NAT (not a managed gateway): egress is only ECR pulls + chain
-    // RPC calls, and this is a non-prod stage — same call the perpcity app made.
-    const vpc = new sst.aws.Vpc("Vpc", { nat: "ec2" });
+    // NAT for egress (ECR pulls + chain RPC). Mirrors the perpcity app: managed
+    // NAT gateway on production (zero-ops), fck-nat EC2 elsewhere (~10x cheaper).
+    const vpc = new sst.aws.Vpc("Vpc", { nat: isProd ? "managed" : "ec2" });
 
     // Wallet pool locks + the component-factory/recipe registries. Single-node
     // Valkey (t4g.micro), matching the service's non-cluster Redis client.
@@ -201,14 +286,14 @@ export default $config({
       architecture: "arm64",
       cpu: "0.5 vCPU",
       memory: "1 GB",
-      // Spot is fine here: writes are short-lived txs, wallet locks expire (60s
-      // TTL), and every operation is retryable by the caller. Revisit for a
-      // production stage.
-      capacity: "spot",
+      // Spot on non-prod: writes are short-lived txs, wallet locks expire (60s
+      // TTL), and every operation is retryable by the caller. On-demand on
+      // production so a Spot reclaim can't interrupt a live signing flow.
+      ...(isProd ? {} : { capacity: "spot" as const }),
       // Exactly one task: the wallet pool serializes writes through Redis locks
       // either way, and one instance keeps tx nonce behavior simple.
       scaling: { min: 1, max: 1 },
-      logging: { retention: "1 month" },
+      logging: { retention: isProd ? "3 months" : "1 month" },
       // ECS injects each secret's value as the named env var at container start
       // (task execution role reads them; SST wires that IAM up from `ssm`).
       ssm: secretArns,
@@ -229,7 +314,7 @@ export default $config({
         },
       },
       environment: {
-        // testnet => Arbitrum Sepolia (chain id 421614) inside the service.
+        // testnet => Arbitrum Sepolia (421614), mainnet => Arbitrum One (42161).
         ENV: stage.env,
         PORT: "8000",
         REDIS_URL: redisUrl,
@@ -237,6 +322,7 @@ export default $config({
         BEACONATOR_INSTANCE_ID: `aws-${$app.stage}`,
         COMPONENT_FACTORIES_JSON: JSON.stringify(stage.componentFactories),
         ...stage.addresses,
+        ...(stage.extraEnvironment ?? {}),
       },
     });
 


### PR DESCRIPTION
## Summary

Migrates the-beaconator's testnet deployment from Railway to AWS (perpcity-dev, 267923960054), managed by SST -- mirroring the conventions of the main perpcity SST app (us-west-2, Fargate arm64, delegated aws.perp.city zone).

### Infrastructure (sst.config.ts)
- New SST app `the-beaconator`, stage `testnet` only (unknown stages refuse to deploy; mainnet stays on Railway until testnet soaks)
- ECS Fargate service (0.5 vCPU / 1 GB, spot) behind an ALB at https://testnet-beaconator.aws.perp.city
- Own VPC (fck-nat) + ElastiCache Valkey for the wallet pool and registries
- Secrets (RPC_URL, PRIVATE_KEY, WALLET_PRIVATE_KEYS, access/admin tokens, SENTRY_DSN) live in **AWS Secrets Manager** under `the-beaconator/testnet/*`, injected by ECS at container start via `valueFrom` -- never in the task definition, SST state, or the repo
- Arbitrum Sepolia contract addresses (2026-06 deployment of beacons@v0.0.1 + perpcity-contracts@v0.1.0) configured per stage; all 29 addresses verified on-chain, BeaconRegistry cross-checked against perpcity-indexer config

### Service changes
- `redis` crate: add `tokio-rustls-comp` so `rediss://` URLs work (ElastiCache requires TLS; local/Railway `redis://` unaffected)
- New optional `COMPONENT_FACTORIES_JSON` env var: a `{"FactoryType": "0xaddr"}` map seeded into the Redis component-factory registry at startup via the previously-unused `seed_defaults` (never overwrites existing entries). Replaces by-hand Redis seeding, which is impossible against a VPC-internal ElastiCache
- Audit list updated; parse helper with unit tests

### Docs
- `docs/AWS_DEPLOY.md`: secret-creation runbook, deploy/verify/rotate/teardown commands

## Test plan
- [x] `make quality` (fmt + clippy + unit + Redis tests) passes
- [x] `docker build` passes with the new Cargo features
- [x] CodeRabbit review (1 minor markdown finding, fixed)
- [ ] First deploy to testnet after secrets are created (runbook step)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS deployment infrastructure via SST + ECS Fargate (testnet & production)
  * Component factory seeding from a JSON env var at startup
  * Redis TLS support for secure connections

* **Documentation**
  * Full AWS deployment guide with secrets, deploy/verify, and rotation steps
  * Updated config docs describing Redis seeding and factory addresses

* **Tests**
  * Unit tests for component-factory JSON parsing

* **Chores**
  * Infra package and deployment scripts added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->