### PR TITLE
CI: release image on merge to main (ECR + SSM param + deploy dispatch)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -39,22 +39,24 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::267923960054:role/perpcity-gha-producer-push
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Log in to ECR
         id: ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/arm64
@@ -71,7 +73,7 @@ jobs:
           echo "wrote $SSM_PARAM = $URI"
 
       - name: Trigger testnet deploy
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.PERPCITY_DISPATCH_TOKEN }}
           repository: StrobeLabs/perpcity-client

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,82 @@
+# Release the beaconator image on every merge to main:
+#   build arm64 -> push to ECR (perpcity-dev) -> write the SSM image parameter
+#   -> dispatch a testnet deploy in perpcity-client.
+#
+# This repo ships the image only; deployment lives in the perpcity SST app
+# (perpcity-client/sst.config.ts), which resolves the image from the
+# /perpcity/testnet/beaconator-image SSM parameter this workflow writes.
+# Production promotion is deliberately manual: copy the image to the prod
+# account's ECR and put /perpcity/production/beaconator-image there.
+#
+# Auth: GitHub OIDC -> perpcity-gha-producer-push role (created by
+# perpcity-client/sst/scripts/gha-oidc-bootstrap.sh). The dispatch hop needs
+# the PERPCITY_DISPATCH_TOKEN secret (PAT with write access to
+# StrobeLabs/perpcity-client).
+name: Release image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-image
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REPO: the-beaconator
+  SSM_PARAM: /perpcity/testnet/beaconator-image
+
+jobs:
+  release:
+    # Native arm64: the Fargate tasks are arm64 and a Rust release build under
+    # QEMU emulation is unusably slow.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::267923960054:role/perpcity-gha-producer-push
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Log in to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          # Immutable tag per commit (the ECR repo enforces immutability).
+          tags: ${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPO }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Write SSM image parameter
+        run: |
+          URI="${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPO }}@${{ steps.build.outputs.digest }}"
+          aws ssm put-parameter --name "$SSM_PARAM" --type String --overwrite --value "$URI"
+          echo "wrote $SSM_PARAM = $URI"
+
+      - name: Trigger testnet deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PERPCITY_DISPATCH_TOKEN }}
+          repository: StrobeLabs/perpcity-client
+          event-type: producer-image-updated
+          client-payload: >-
+            {"image": "${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPO }}@${{ steps.build.outputs.digest }}",
+             "repo": "${{ github.repository }}",
+             "sha": "${{ github.sha }}"}


### PR DESCRIPTION
On every merge to main: build the arm64 image natively, push to ECR in perpcity-dev tagged with the commit SHA, write `/perpcity/testnet/beaconator-image` (URI pinned by digest) to SSM, and fire a `repository_dispatch` that triggers `sst deploy --stage testnet` in perpcity-client.

This completes the image contract from StrobeLabs/perpcity-client#385 — deployment resolves the image from that SSM parameter, so "merge to the-beaconator main" now rolls testnet end to end with no manual steps. Production promotion stays manual (copy image to prod ECR + put the prod parameter).

Prereqs before the first run (documented in the workflow header):
- `perpcity-gha-producer-push` OIDC role (perpcity-client `sst/scripts/gha-oidc-bootstrap.sh perpcity-dev`)
- `PERPCITY_DISPATCH_TOKEN` repo secret (PAT with write on perpcity-client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to build and publish an arm64 container image on pushes to main or manual dispatch.
  * Published image to the container registry with immutable digest URI and updated a configuration parameter with that URI.
  * Sends a downstream notification to the client repository when a new image is published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->