### PR TITLE
Poll get_code in verify_deployed to tolerate load-balanced RPC replica lag

### DIFF
--- a/src/services/beacon/mod.rs
+++ b/src/services/beacon/mod.rs
@@ -26,19 +26,45 @@ pub use verifiable::*;
 /// changed between simulate and send, nonce drift, factory semantics), the flow
 /// would register/return an address with no code behind it. A code-presence
 /// check after the receipt catches that class of bug.
+///
+/// The check polls instead of reading once: load-balanced RPC providers (seen
+/// consistently with Alchemy on Arbitrum Sepolia) can serve `eth_getCode` from
+/// a replica that lags the node that confirmed the receipt, so an immediate
+/// single read false-negatives on freshly deployed code. A genuinely wrong
+/// prediction still fails once the poll budget is exhausted.
 pub async fn verify_deployed(
     provider: &impl alloy::providers::Provider,
     addr: alloy::primitives::Address,
     label: &str,
 ) -> Result<(), String> {
-    match provider.get_code_at(addr).await {
-        Ok(code) if code.is_empty() => Err(format!(
+    const ATTEMPTS: u32 = 12;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+
+    let mut last_rpc_error: Option<String> = None;
+    for attempt in 1..=ATTEMPTS {
+        match provider.get_code_at(addr).await {
+            Ok(code) if !code.is_empty() => {
+                if attempt > 1 {
+                    tracing::info!(
+                        "{label} code at {addr} appeared on attempt {attempt} (RPC replica lag)"
+                    );
+                }
+                return Ok(());
+            }
+            Ok(_) => last_rpc_error = None,
+            Err(e) => last_rpc_error = Some(e.to_string()),
+        }
+        if attempt < ATTEMPTS {
+            tokio::time::sleep(RETRY_DELAY).await;
+        }
+    }
+    match last_rpc_error {
+        Some(e) => Err(format!(
+            "Failed to verify {label} deployment at {addr}: {e}"
+        )),
+        None => Err(format!(
             "{label} at {addr} has no deployed code after confirmation — predicted CREATE \
              address may be wrong; refusing to use it"
-        )),
-        Ok(_) => Ok(()),
-        Err(e) => Err(format!(
-            "Failed to verify {label} deployment at {addr}: {e}"
         )),
     }
 }


### PR DESCRIPTION
## Summary

The post-deploy code-presence check added in #62 (`verify_deployed`) reads `eth_getCode` exactly once, immediately after the receipt. Behind a load-balanced RPC (Alchemy Arbitrum Sepolia), the read routinely lands on a replica that lags the node that confirmed the receipt, so the check false-negatives on freshly deployed contracts and the whole beacon-creation flow aborts.

Observed twice in a row on the Railway testnet instance tonight: `createVerifier` receipt confirmed (status 1, code on-chain at the predicted address, verified with cast), yet `create_beacon_with_ecdsa` failed ~20ms later with "has no deployed code after confirmation". Orphaned-but-valid verifiers at 0x20faf86b92d7e678d0E91eD178119B754426A12E and 0xaa1c84826aec38fad0f351D533466A6EEe152Ca4 are the receipts of those races.

Fix: poll `get_code_at` up to 12 times at 500ms intervals (6s budget) before declaring the address empty. A genuinely wrong CREATE prediction still fails after the budget; replica lag now just delays the success path by one round-trip. Logs when code appears on a retry so the lag stays visible.

This will equally affect the AWS deployment (same Alchemy-style RPC fleet), so it should land regardless of the Railway use.

## Test plan
- [x] fmt + clippy + unit tests pass
- [x] Deployed to Railway testnet; beacon creation succeeds where it previously failed twice (see PR comment shortly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced contract deployment verification to be more resilient against RPC network delays, reducing false failures and providing clearer diagnostic messages when deployments cannot be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->