### PR TITLE
Fix startup panic: install rustls CryptoProvider explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ schemars = { version = "0.8", features = ["preserve_order"] }
 # TLS, so the REDIS_URL is `rediss://` — without a TLS feature Client::open fails
 # to connect. Plain `redis://` (local/tests) still works; the scheme decides.
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "aio", "tokio-rustls-comp", "tls-rustls-webpki-roots"] }
+# Direct dep solely to install the process-level CryptoProvider at startup
+# (src/main.rs): with redis's tls-rustls + reqwest's rustls-tls in the same
+# tree, rustls 0.23 cannot infer a provider on its own and panics at the first
+# TLS connection (the ElastiCache rediss:// connect). ring matches the provider
+# already present in the dependency tree.
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 hostname = "0.4"
 # UUID for instance identification
 uuid = { version = "1.0", features = ["v4"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,14 @@ use the_beaconator::create_rocket;
 
 #[rocket::launch]
 async fn rocket() -> _ {
+    // Pin the process-level rustls CryptoProvider BEFORE anything opens a TLS
+    // connection. The dependency tree carries rustls via both redis
+    // (tls-rustls, for ElastiCache rediss://) and reqwest (rustls-tls), and
+    // rustls 0.23 panics at the first TLS handshake when it cannot infer
+    // exactly one provider. Ignore the Err case: it means a provider is
+    // already installed, which is the desired end state.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // Initialize logging first with environment variable support
     use tracing_subscriber::{EnvFilter, fmt};
 


### PR DESCRIPTION
On ECS the task crash-looped at the first TLS connection (ElastiCache `rediss://`):

> PANIC … rustls-0.23 … Could not automatically determine the process-level CryptoProvider from Rustls crate features.

The tree carries rustls via both redis (`tls-rustls`) and reqwest (`rustls-tls`) and no single provider feature wins, so rustls 0.23 refuses to guess. Fix: install the `ring` provider explicitly at process start (it's the provider already in the dependency tree); `Err` from `install_default()` means one is already installed, which is fine.

Verified: clippy clean, unit tests pass; the panic reproduces only against TLS Redis (ECS), local `redis://` tests don't exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential crashes when establishing secure Redis connections alongside other TLS dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->