### PR TITLE
Document release hygiene: main soaks testnet, production deploys the release branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,12 @@ Five module addresses, all required, all deployed once and reused across markets
 - Batch operations continue on individual failures with detailed error reporting
 - Network errors gracefully handled in test environment
 
+## Releases
+`main` auto-deploys to testnet only. Production (Railway `the-mainnet-beaconator`)
+deploys the `release` branch; promotion = fast-forward `release` to a soaked
+main commit + annotated tag (see README "Releases and deployment"). Never point
+production at `main`.
+
 ## Git Commit Guidelines
 - Use concise commit messages (1 sentence max)
 - Do not include Claude Code attribution or co-author tags (private repo)

--- a/README.md
+++ b/README.md
@@ -146,3 +146,33 @@ You can view interactive API documentation using any OpenAPI UI viewer:
 
 
 This project is open source and available under the [MIT License](LICENSE).
+
+## Releases and deployment
+
+`main` is the integration branch: every merge auto-deploys to the **testnet**
+beaconator (Railway, `the-beaconator` service) for soak. Production never
+tracks `main`.
+
+The **`release` branch is what production deploys** (Railway
+`the-mainnet-beaconator`; the AWS image promotion described in the workflow
+follows the same philosophy). Promoting to production is a deliberate act:
+
+```bash
+# 1. After the candidate commit has soaked on testnet:
+git fetch origin
+git push origin <commit>:release
+
+# 2. Tag it (always; bump minor for contract-pin changes):
+git tag -a vX.Y.Z <commit> -m "what changed"
+git push origin vX.Y.Z
+```
+
+Rules:
+- Never point production at `main`. The 2026-06-09 incident: an ECS-targeted
+  Dockerfile change merged to `main` and auto-deployed to the production
+  beaconator overnight, silently breaking Railway private networking for
+  every updater that calls it.
+- `release` only ever fast-forwards to commits that are ancestors of `main`
+  (i.e. went through PR review + CI + testnet soak). No direct commits.
+- Cut a tag per promotion. Contract-pin bumps (`.contracts-versions`) always
+  get their own tag.


### PR DESCRIPTION
Follow-up to last night's incident: the production mainnet beaconator was auto-deploying every merge to main, which silently rolled out #62's ECS-targeted Dockerfile (IPv4-only bind) and broke Railway private networking for every updater calling it (~13h of stale Hormuz mainnet beacons until diagnosed).

Changes (process, no code):
- New long-lived `release` branch, created at the currently-deployed prod commit (6d622f5) and tagged `v0.1.0` (first tag in this repo; per our convention, contract-pin bumps always get their own tag).
- The Railway `the-mainnet-beaconator` service is being repointed from `main` to `release` (dashboard change, done separately).
- README + CLAUDE.md document the promotion flow: merge to main -> auto-deploy testnet -> soak -> deliberately fast-forward `release` + tag.

The AWS deployment already follows this philosophy (image released on merge, production promotion manual); this brings the Railway side in line until the AWS cutover retires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release and deployment process documentation
  * Defines main branch for integration with auto-testnet deployment
  * Specifies production deployments exclusively from release branch
  * Documents promotion procedures using fast-forward commits and version tagging
  * Establishes deployment constraints and rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->