### PR TITLE
feat: add mainnet-capable /fund_bonus_wallet route

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ fn audit_environment() {
     const OTHER_VARS_OPTIONAL: &[&str] = &[
         "USDC_TRANSFER_LIMIT",
         "ETH_TRANSFER_LIMIT",
+        "USDC_BONUS_LIMIT",
         "BEACONATOR_INSTANCE_ID",
         "RUST_LOG",
         "SENTRY_TRACES_SAMPLE_RATE",
@@ -385,6 +386,11 @@ pub async fn create_rocket() -> Rocket<Build> {
         .unwrap_or_else(|_| "10000000000000000".to_string()) // Default 0.01 ETH
         .parse::<u128>()
         .expect("Failed to parse ETH_TRANSFER_LIMIT");
+
+    let usdc_bonus_limit = env::var("USDC_BONUS_LIMIT")
+        .unwrap_or_else(|_| "50000000".to_string()) // Default 50 USDC
+        .parse::<u128>()
+        .expect("Failed to parse USDC_BONUS_LIMIT");
 
     // Get environment configuration and chain ID
     let env_type = &rpc_config.env_type;
@@ -733,6 +739,7 @@ pub async fn create_rocket() -> Rocket<Build> {
             signer,
             usdc_transfer_limit,
             eth_transfer_limit,
+            usdc_bonus_limit,
         },
         contracts: ContractAddresses {
             perpcity_registry: perpcity_registry_address,
@@ -779,6 +786,7 @@ pub async fn create_rocket() -> Rocket<Build> {
         routes::perp::deploy_perp_for_beacon_endpoint,
         routes::perp::deposit_liquidity_for_perp_endpoint,
         routes::wallet::fund_guest_wallet,
+        routes::wallet::fund_bonus_wallet,
         routes::beacon_type::list_beacon_types,
         routes::beacon_type::get_beacon_type,
         routes::beacon_type::register_beacon_type,

--- a/src/models/app_state.rs
+++ b/src/models/app_state.rs
@@ -206,6 +206,9 @@ pub struct WalletConfig {
     pub signer: PrivateKeySigner,
     pub usdc_transfer_limit: u128,
     pub eth_transfer_limit: u128,
+    /// Per-request USDC cap for the mainnet bonus route (`/fund_bonus_wallet`).
+    /// Tighter than `usdc_transfer_limit` because it bounds real-money payouts.
+    pub usdc_bonus_limit: u128,
 }
 
 #[derive(Clone)]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -18,8 +18,7 @@ pub use requests::{
     CreateBeaconWithEcdsaRequest, CreateLBCGBMBeaconRequest,
     CreateWeightedSumCompositeBeaconRequest, DeployPerpForBeaconRequest,
     DepositLiquidityForPerpRequest, FundBonusWalletRequest, FundGuestWalletRequest,
-    RegisterBeaconRequest,
-    RegisterBeaconTypeRequest, UpdateBeaconRequest, UpdateBeaconTypeRequest,
+    RegisterBeaconRequest, RegisterBeaconTypeRequest, UpdateBeaconRequest, UpdateBeaconTypeRequest,
     UpdateBeaconWithEcdsaRequest,
 };
 pub use requests::{CreateModularBeaconRequest, ModularBeaconParams};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -17,7 +17,8 @@ pub use requests::{
     BatchUpdateBeaconRequest, BeaconCreationParams, BeaconUpdateData, CreateBeaconByTypeRequest,
     CreateBeaconWithEcdsaRequest, CreateLBCGBMBeaconRequest,
     CreateWeightedSumCompositeBeaconRequest, DeployPerpForBeaconRequest,
-    DepositLiquidityForPerpRequest, FundGuestWalletRequest, RegisterBeaconRequest,
+    DepositLiquidityForPerpRequest, FundBonusWalletRequest, FundGuestWalletRequest,
+    RegisterBeaconRequest,
     RegisterBeaconTypeRequest, UpdateBeaconRequest, UpdateBeaconTypeRequest,
     UpdateBeaconWithEcdsaRequest,
 };

--- a/src/models/requests.rs
+++ b/src/models/requests.rs
@@ -234,6 +234,19 @@ pub struct FundGuestWalletRequest {
     pub eth_amount: String,
 }
 
+/// Fund a wallet with the new-user bonus USDC.
+///
+/// Unlike `FundGuestWalletRequest`, this carries NO ETH leg: the recipient is a
+/// smart account whose trades are paymaster-sponsored, so it never needs gas.
+/// This request backs the mainnet-capable `/fund_bonus_wallet` route.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FundBonusWalletRequest {
+    /// Smart-account address to fund (counterfactual is fine)
+    pub wallet_address: String,
+    /// USDC amount in 6 decimals (e.g., "50000000" for 50 USDC)
+    pub usdc_amount: String,
+}
+
 /// Update a beacon using ECDSA signature from the beaconator wallet
 ///
 /// This endpoint signs the measurement with the beaconator wallet and submits

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -15,7 +15,7 @@ const FUNDING_RECEIPT_TIMEOUT: Duration = Duration::from_secs(120);
 
 use super::{IERC20, sentry_error};
 use crate::guards::ApiToken;
-use crate::models::{ApiResponse, AppState, FundGuestWalletRequest};
+use crate::models::{ApiResponse, AppState, FundBonusWalletRequest, FundGuestWalletRequest};
 
 /// Production chain ids the beaconator can target. Any chain id NOT in the testnet/local
 /// allow-list (Arbitrum Sepolia = 421614, Anvil default = 31337) is treated as production
@@ -477,6 +477,279 @@ pub async fn fund_guest_wallet(
             usdc_receipt.transaction_hash
         )),
         message: "Guest wallet funded successfully".to_string(),
+    }))
+}
+
+/// Funds a wallet with the new-user bonus USDC (mainnet-capable).
+///
+/// The sibling of `fund_guest_wallet` for the real-money $50 bonus. Differences:
+///   - USDC only, NO ETH leg — the recipient is a smart account whose trades are
+///     paymaster-sponsored, so it never needs gas.
+///   - Runs on ALL chains, including Arbitrum One: there is NO production
+///     guardrail here, because disbursing real mainnet USDC is the entire point.
+///     The real-money safety lives in (a) the tighter `usdc_bonus_limit` cap,
+///     (b) the bearer-token auth, and (c) the caller's own kill-switch + atomic
+///     single-use claim. The faucet route keeps its mainnet guard untouched.
+#[openapi(tag = "Wallet")]
+#[post("/fund_bonus_wallet", format = "json", data = "<request>")]
+pub async fn fund_bonus_wallet(
+    state: &State<AppState>,
+    request: Json<FundBonusWalletRequest>,
+    _token: ApiToken,
+) -> Result<Json<ApiResponse<String>>, (Status, Json<ApiResponse<String>>)> {
+    tracing::info!("Received request: POST /fund_bonus_wallet");
+    let hub = sentry::Hub::new_from_top(sentry::Hub::main());
+    hub.add_breadcrumb(sentry::Breadcrumb {
+        ty: "http".into(),
+        category: Some("request".into()),
+        message: Some(format!(
+            "POST /fund_bonus_wallet wallet={}",
+            request.wallet_address
+        )),
+        ..Default::default()
+    });
+    hub.configure_scope(|scope| {
+        scope.set_tag("endpoint", "/fund_bonus_wallet");
+        scope.set_extra("wallet_address", request.wallet_address.clone().into());
+        scope.set_extra("usdc_amount", request.usdc_amount.clone().into());
+    });
+
+    let wallet_address = match Address::from_str(&request.wallet_address) {
+        Ok(addr) => addr,
+        Err(e) => {
+            return Err((
+                Status::BadRequest,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: format!("Invalid wallet address: {e}"),
+                }),
+            ));
+        }
+    };
+
+    let usdc_amount = match request.usdc_amount.parse::<u128>() {
+        Ok(amount) => amount,
+        Err(e) => {
+            return Err((
+                Status::BadRequest,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: format!("Invalid USDC amount: {e}"),
+                }),
+            ));
+        }
+    };
+
+    // Bound each payout by the dedicated bonus cap (real money — fail closed).
+    if usdc_amount == 0 || usdc_amount > state.wallets.usdc_bonus_limit {
+        return Err((
+            Status::BadRequest,
+            Json(ApiResponse {
+                success: false,
+                data: None,
+                message: format!(
+                    "USDC amount out of range. Requested: {} USDC, Limit: {} USDC",
+                    usdc_amount / 1_000_000,
+                    state.wallets.usdc_bonus_limit / 1_000_000
+                ),
+            }),
+        ));
+    }
+
+    tracing::info!(
+        "Funding bonus wallet: {} with {} USDC",
+        wallet_address,
+        usdc_amount / 1_000_000
+    );
+
+    // Check funding wallet USDC balance using read provider
+    let usdc_read_contract = IERC20::new(state.contracts.usdc, &*state.provider.read_provider);
+    let usdc_balance = match usdc_read_contract
+        .balanceOf(state.wallets.funding_address)
+        .call()
+        .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            let detailed_error = format!("Failed to get USDC balance: {e}");
+            tracing::error!("{}", detailed_error);
+            sentry_error(&hub, "RpcError", detailed_error, vec![]);
+            return Err((
+                Status::InternalServerError,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: "Failed to retrieve USDC balance".to_string(),
+                }),
+            ));
+        }
+    };
+
+    if usdc_balance < U256::from(usdc_amount) {
+        tracing::warn!(
+            "Insufficient USDC balance in funding wallet {}. Have: {} USDC, Need: {} USDC",
+            state.wallets.funding_address,
+            usdc_balance / U256::from(1_000_000),
+            usdc_amount / 1_000_000
+        );
+        hub.capture_message(
+            &format!(
+                "Insufficient USDC balance in bonus funding wallet. Have: {} USDC, Need: {} USDC",
+                usdc_balance / U256::from(1_000_000),
+                usdc_amount / 1_000_000
+            ),
+            sentry::Level::Warning,
+        );
+        return Err((
+            Status::InternalServerError,
+            Json(ApiResponse {
+                success: false,
+                data: None,
+                message: format!(
+                    "Insufficient USDC balance. Have: {} USDC, Need: {} USDC",
+                    usdc_balance / U256::from(1_000_000),
+                    usdc_amount / 1_000_000
+                ),
+            }),
+        ));
+    }
+
+    // Acquire distributed lock on funding wallet to prevent nonce conflicts
+    // across concurrent requests and multiple beaconator instances.
+    let funding_lock = state
+        .wallets
+        .manager
+        .acquire_lock(&state.wallets.funding_address)
+        .await
+        .map_err(|e| {
+            let detailed_error = format!("Failed to acquire funding wallet lock: {e}");
+            tracing::error!("{}", detailed_error);
+            sentry_error(&hub, "WalletError", detailed_error, vec![]);
+            (
+                Status::ServiceUnavailable,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: "Funding wallet temporarily unavailable".to_string(),
+                }),
+            )
+        })?;
+
+    // Keep the lock alive across the transfer confirmation. Declared after the
+    // lock so it drops first: the heartbeat is aborted BEFORE the lock releases.
+    let funding_heartbeat = funding_lock.spawn_heartbeat(state.wallets.manager.lock_ttl());
+
+    // Build a fresh provider per-request to avoid stale nonce caching.
+    let funding_wallet = EthereumWallet::from(state.wallets.signer.clone());
+    let rpc_url = state.provider.rpc_url.parse().map_err(|e| {
+        let detailed_error = format!("Invalid RPC URL in AppState: {e}");
+        tracing::error!("{}", detailed_error);
+        sentry_error(&hub, "ConfigError", detailed_error, vec![]);
+        (
+            Status::InternalServerError,
+            Json(ApiResponse {
+                success: false,
+                data: None,
+                message: "Server RPC configuration is invalid".to_string(),
+            }),
+        )
+    })?;
+    let funding_provider = ProviderBuilder::new()
+        .wallet(funding_wallet)
+        .connect_http(rpc_url);
+
+    // Confirm the lock is still held immediately before submitting.
+    if let Err(e) = funding_heartbeat.ensure_held() {
+        let detailed_error = format!("Funding wallet lock lost before USDC transfer: {e}");
+        tracing::error!("{}", detailed_error);
+        sentry_error(&hub, "WalletError", detailed_error, vec![]);
+        return Err((
+            Status::InternalServerError,
+            Json(ApiResponse {
+                success: false,
+                data: None,
+                message: format!("USDC transfer aborted: {e}"),
+            }),
+        ));
+    }
+
+    // Send USDC using funding provider.
+    let usdc_send_contract = IERC20::new(state.contracts.usdc, &funding_provider);
+    let usdc_receipt = match usdc_send_contract
+        .transfer(wallet_address, U256::from(usdc_amount))
+        .send()
+        .await
+    {
+        Ok(pending) => {
+            let usdc_tx_hash = *pending.tx_hash();
+            match timeout(FUNDING_RECEIPT_TIMEOUT, pending.get_receipt()).await {
+                Ok(Ok(receipt)) => receipt,
+                Ok(Err(e)) => {
+                    let detailed_error = format!("Failed to get USDC transaction receipt: {e}");
+                    tracing::error!("{}", detailed_error);
+                    sentry_error(&hub, "TransactionError", detailed_error, vec![]);
+                    return Err((
+                        Status::InternalServerError,
+                        Json(ApiResponse {
+                            success: false,
+                            data: None,
+                            message: format!(
+                                "USDC transfer sent (tx {usdc_tx_hash:?}) but confirmation \
+                                 failed — verify on-chain before retrying to avoid double-funding"
+                            ),
+                        }),
+                    ));
+                }
+                Err(_) => {
+                    let detailed_error = format!(
+                        "Timeout waiting for USDC transfer receipt (tx {usdc_tx_hash:?}) after {}s",
+                        FUNDING_RECEIPT_TIMEOUT.as_secs()
+                    );
+                    tracing::error!("{}", detailed_error);
+                    sentry_error(&hub, "TransactionError", detailed_error, vec![]);
+                    return Err((
+                        Status::InternalServerError,
+                        Json(ApiResponse {
+                            success: false,
+                            data: None,
+                            message: format!(
+                                "USDC transfer unconfirmed after {}s (tx {usdc_tx_hash:?}) — \
+                                 verify on-chain before retrying to avoid double-funding",
+                                FUNDING_RECEIPT_TIMEOUT.as_secs()
+                            ),
+                        }),
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            let detailed_error = format!("Failed to send USDC: {e}");
+            tracing::error!("{}", detailed_error);
+            sentry_error(&hub, "TransactionError", detailed_error, vec![]);
+            return Err((
+                Status::InternalServerError,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: "Failed to send USDC".to_string(),
+                }),
+            ));
+        }
+    };
+
+    tracing::info!("Bonus USDC transfer hash: {:?}", usdc_receipt.transaction_hash);
+
+    Ok(Json(ApiResponse {
+        success: true,
+        data: Some(format!(
+            "Successfully funded wallet {} with {} USDC. USDC tx: {:?}",
+            wallet_address,
+            usdc_amount / 1_000_000,
+            usdc_receipt.transaction_hash
+        )),
+        message: "Bonus wallet funded successfully".to_string(),
     }))
 }
 

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -685,6 +685,27 @@ pub async fn fund_bonus_wallet(
         Ok(pending) => {
             let usdc_tx_hash = *pending.tx_hash();
             match timeout(FUNDING_RECEIPT_TIMEOUT, pending.get_receipt()).await {
+                // A receipt can come back for a REVERTED transfer — accepting it
+                // would report a successful payout when no USDC moved. Treat a
+                // non-success status as a failure (no funds moved on a revert, so
+                // it is safe to retry once the cause is understood).
+                Ok(Ok(receipt)) if !receipt.status() => {
+                    let detailed_error =
+                        format!("USDC transfer reverted on-chain (tx {usdc_tx_hash:?})");
+                    tracing::error!("{}", detailed_error);
+                    sentry_error(&hub, "TransactionError", detailed_error, vec![]);
+                    return Err((
+                        Status::InternalServerError,
+                        Json(ApiResponse {
+                            success: false,
+                            data: None,
+                            message: format!(
+                                "USDC transfer reverted on-chain (tx {usdc_tx_hash:?}); \
+                                 no USDC moved"
+                            ),
+                        }),
+                    ));
+                }
                 Ok(Ok(receipt)) => receipt,
                 Ok(Err(e)) => {
                     let detailed_error = format!("Failed to get USDC transaction receipt: {e}");
@@ -739,17 +760,21 @@ pub async fn fund_bonus_wallet(
         }
     };
 
-    tracing::info!("Bonus USDC transfer hash: {:?}", usdc_receipt.transaction_hash);
+    tracing::info!(
+        "Bonus USDC transfer hash: {:?}",
+        usdc_receipt.transaction_hash
+    );
 
+    // `data` is the transaction hash itself (not a sentence) so callers can
+    // consume it directly without parsing prose. The human-readable summary
+    // lives in `message`.
     Ok(Json(ApiResponse {
         success: true,
-        data: Some(format!(
-            "Successfully funded wallet {} with {} USDC. USDC tx: {:?}",
-            wallet_address,
-            usdc_amount / 1_000_000,
-            usdc_receipt.transaction_hash
-        )),
-        message: "Bonus wallet funded successfully".to_string(),
+        data: Some(usdc_receipt.transaction_hash.to_string()),
+        message: format!(
+            "Successfully funded wallet {wallet_address} with {} USDC",
+            usdc_amount / 1_000_000
+        ),
     }))
 }
 

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -568,7 +568,7 @@ pub async fn create_test_app_state() -> AppState {
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
-            usdc_bonus_limit: 50_000_000,               // 50 USDC
+            usdc_bonus_limit: 50_000_000,       // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: deployment.beacon_registry,
@@ -637,7 +637,7 @@ pub async fn create_isolated_test_app_state() -> (AppState, AnvilManager) {
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
-            usdc_bonus_limit: 50_000_000,               // 50 USDC
+            usdc_bonus_limit: 50_000_000,       // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: deployment.beacon_registry,
@@ -797,7 +797,7 @@ pub async fn create_test_app_state_with_account(account_index: usize) -> AppStat
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
-            usdc_bonus_limit: 50_000_000,               // 50 USDC
+            usdc_bonus_limit: 50_000_000,       // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: deployment.beacon_registry,
@@ -913,7 +913,7 @@ pub async fn create_simple_test_app_state() -> AppState {
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
-            usdc_bonus_limit: 50_000_000,               // 50 USDC
+            usdc_bonus_limit: 50_000_000,       // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: Address::from_str("0x2345678901234567890123456789012345678901")
@@ -979,7 +979,7 @@ pub async fn create_test_app_state_with_provider(
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
-            usdc_bonus_limit: 50_000_000,               // 50 USDC
+            usdc_bonus_limit: 50_000_000,       // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: Address::from_str("0x2345678901234567890123456789012345678901")

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -568,6 +568,7 @@ pub async fn create_test_app_state() -> AppState {
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
+            usdc_bonus_limit: 50_000_000,               // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: deployment.beacon_registry,
@@ -636,6 +637,7 @@ pub async fn create_isolated_test_app_state() -> (AppState, AnvilManager) {
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
+            usdc_bonus_limit: 50_000_000,               // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: deployment.beacon_registry,
@@ -729,6 +731,7 @@ pub async fn create_isolated_test_app_state_with_redis() -> (AppState, AnvilMana
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000,
             eth_transfer_limit: 10_000_000_000_000_000,
+            usdc_bonus_limit: 50_000_000,
         },
         contracts: ContractAddresses {
             perpcity_registry: deployment.beacon_registry,
@@ -794,6 +797,7 @@ pub async fn create_test_app_state_with_account(account_index: usize) -> AppStat
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
+            usdc_bonus_limit: 50_000_000,               // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: deployment.beacon_registry,
@@ -909,6 +913,7 @@ pub async fn create_simple_test_app_state() -> AppState {
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
+            usdc_bonus_limit: 50_000_000,               // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: Address::from_str("0x2345678901234567890123456789012345678901")
@@ -974,6 +979,7 @@ pub async fn create_test_app_state_with_provider(
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
+            usdc_bonus_limit: 50_000_000,               // 50 USDC
         },
         contracts: ContractAddresses {
             perpcity_registry: Address::from_str("0x2345678901234567890123456789012345678901")


### PR DESCRIPTION
## What

Adds `POST /fund_bonus_wallet` to disburse the \$50 new-user bonus USDC on **Arbitrum One**. Pairs with StrobeLabs/perpcity-client#501, whose backend `/redeem_bonus` calls this route.

## Why a new route instead of relaxing `/fund_guest_wallet`

`/fund_guest_wallet` is hard-disabled on production chains (the `is_production_chain` 403 guard) — a deliberate safety boundary for the testnet faucet. Relaxing it to allow mainnet would weaken that boundary and couple the faucet with a real-money path. Instead this adds a purpose-built sibling and leaves the faucet route **completely untouched**.

## The route

- **USDC only, no ETH leg** — the recipient is a smart account whose trades are paymaster-sponsored, so it never needs gas.
- **Runs on all chains incl. mainnet** — no production guard here; disbursing real USDC is the point. Real-money safety comes from (a) the tighter `usdc_bonus_limit` cap, (b) bearer-token auth, and (c) the caller's kill-switch + atomic single-use claim.
- Reuses the existing signer, **Redis funding-wallet lock**, fresh-provider-per-request, and 120s receipt-timeout handling.

## Changes

- `routes/wallet.rs`: `fund_bonus_wallet` handler
- `models/requests.rs`: `FundBonusWalletRequest { wallet_address, usdc_amount }`
- `models/app_state.rs`: `usdc_bonus_limit` on `WalletConfig`
- `lib.rs`: parse `USDC_BONUS_LIMIT` (default 50000000 = 50 USDC), wire it, mount the route, add to env audit
- `tests/test_utils.rs`: new field in the 6 `WalletConfig` builders

## Config

- `USDC_BONUS_LIMIT` — per-request USDC cap (default 50 USDC).
- Requires the mainnet signer funded with a USDC float + ETH for gas.

## Note

Authored without a local Rust toolchain — please confirm `cargo check`, `cargo test`, and `cargo fmt --check` are green in CI before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new bonus wallet funding API endpoint (`POST /fund_bonus_wallet`) with a dedicated request payload for USDC-only transfers.
  * Introduced an optional startup configuration (`USDC_BONUS_LIMIT`, defaulting to `50000000`) to cap real-money bonus payouts.

* **Bug Fixes**
  * Strengthened request validation and out-of-range/zero amount rejection for bonus transfers.
  * Improved reliability and error reporting around lock handling, on-chain transfer execution, and receipt success/timeout scenarios.

* **Tests**
  * Updated test app-state builders to include the new bonus limit configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->