### PR TITLE
chore: upgrade alloy 1.5 -> 2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ rocket = { version = "0.5.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-alloy = { version = "1.5", features = ["full", "node-bindings"] }
+alloy = { version = "2.1", features = ["full", "node-bindings"] }
 dotenvy = "0.15.7"
 sentry = { version = "0.32", features = ["anyhow", "tracing"] }
 tracing = "0.1"


### PR DESCRIPTION
## What
Upgrade the `alloy` dependency from `1.5` (resolving to 1.6.1) to `2.1` (latest, 2.1.0).

## Why
Prerequisite for the upcoming KMS-backed signer work: the beaconator will move its `PRIVATE_KEY` (EIP-712 measurement signer) and `WALLET_PRIVATE_KEYS` (gas-payer pool) onto AWS KMS via alloy's `AwsSigner` (`signer-aws` feature). Getting onto the latest alloy first keeps that change on a current, supported API rather than layering it on a year-old major version.

## Scope
One-line version bump. `Cargo.lock` is gitignored in this repo, so there is no lockfile churn to review; CI resolves `2.1` fresh.

## Verification (local, all green)
- `make build` - clean compile against alloy 2.1.0, zero errors (the code already used the modern `connect_http` / `sol!` patterns, so no source changes were needed).
- `make lint` - clippy (strict, CI config): clean.
- `make fmt-check` - clean.
- `make test` - full CI-style suite: 175 + 20 + 7 pass, 0 failures (network-live integration tests `ignored` as usual).

No source or behavior changes; this is a dependency bump only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to a newer major version while keeping existing features enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->