### PR TITLE
feat: kms-wallet CLI (generate KMS signing key + print address)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,14 @@ rocket = { version = "0.5.1", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-alloy = { version = "2.1", features = ["full", "node-bindings"] }
+alloy = { version = "2.1", features = ["full", "node-bindings", "signer-aws"] }
+# AWS KMS signing: keys live in KMS (non-exportable), signed via kms:Sign, address
+# derived via kms:GetPublicKey. aws-sdk-kms is kept in the same 1.x line alloy's
+# signer-aws depends on so the `aws_sdk_kms::Client` type unifies with AwsSigner.
+aws-config = "1"
+aws-sdk-kms = "1"
+# CLI arg parsing for the kms-wallet operator binary (src/bin/kms-wallet.rs).
+clap = { version = "4", features = ["derive"] }
 dotenvy = "0.15.7"
 sentry = { version = "0.32", features = ["anyhow", "tracing"] }
 tracing = "0.1"

--- a/src/bin/kms-wallet.rs
+++ b/src/bin/kms-wallet.rs
@@ -59,6 +59,21 @@ fn alias_name(stage: &str, role: &str) -> String {
     format!("alias/perpcity/{stage}/{role}")
 }
 
+/// Whether `alias` already exists in this account/region (paginates all aliases).
+async fn alias_exists(client: &Client, alias: &str) -> Result<bool, Box<dyn std::error::Error>> {
+    let mut pages = client.list_aliases().into_paginator().send();
+    while let Some(page) = pages.next().await {
+        if page?
+            .aliases()
+            .iter()
+            .any(|entry| entry.alias_name() == Some(alias))
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
@@ -91,6 +106,15 @@ async fn create(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let alias = alias_name(stage, role);
 
+    // Fail before creating a key if the alias is already taken, so we never leak an
+    // orphaned (unaliased) KMS key.
+    if alias_exists(client, &alias).await? {
+        return Err(format!(
+            "alias {alias} already exists; choose a different --stage/--role or remove the existing alias first"
+        )
+        .into());
+    }
+
     let out = client
         .create_key()
         .key_spec(KeySpec::EccSecgP256K1)
@@ -111,14 +135,26 @@ async fn create(
         .key_metadata()
         .ok_or("CreateKey returned no key metadata")?;
     let key_id = meta.key_id().to_string();
-    let key_arn = meta.arn().unwrap_or_default().to_string();
+    let key_arn = meta
+        .arn()
+        .ok_or("CreateKey returned no key ARN")?
+        .to_string();
 
-    client
+    // If aliasing fails after the key exists, surface the orphaned key id rather than
+    // leaking it silently - the operator can alias or schedule-delete it.
+    if let Err(err) = client
         .create_alias()
         .alias_name(&alias)
         .target_key_id(&key_id)
         .send()
-        .await?;
+        .await
+    {
+        return Err(format!(
+            "created key {key_id} ({key_arn}) but failed to alias it {alias}: {err}; \
+             the key is orphaned - alias or schedule-delete it manually"
+        )
+        .into());
+    }
 
     let address = derive_address(client, &key_id).await?;
 

--- a/src/bin/kms-wallet.rs
+++ b/src/bin/kms-wallet.rs
@@ -1,0 +1,154 @@
+//! kms-wallet: generate and inspect AWS KMS secp256k1 Ethereum signing keys.
+//!
+//! The private key is generated inside AWS KMS and can never be exported. Operators
+//! get the derived Ethereum address (to fund the wallet) and services sign via IAM
+//! `kms:Sign`, but no API returns the key material. This is the replacement for
+//! plaintext private keys stored in AWS Secrets Manager.
+//!
+//! Usage:
+//!   kms-wallet create  --stage <stage> --role <role>   # make a key + alias, print address
+//!   kms-wallet address --key <alias|id|arn>            # print address for an existing key
+//!
+//! AWS credentials/region are resolved via the standard chain; override with --profile
+//! (e.g. --profile perpcity-dev) and/or --region.
+
+use alloy::primitives::Address;
+use alloy::signers::{Signer, aws::AwsSigner};
+use aws_config::BehaviorVersion;
+use aws_sdk_kms::Client;
+use aws_sdk_kms::types::{KeySpec, KeyUsageType, Tag};
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    name = "kms-wallet",
+    about = "Generate/inspect AWS KMS secp256k1 Ethereum signing keys"
+)]
+struct Cli {
+    /// AWS profile to use (falls back to the default credential chain / AWS_PROFILE).
+    #[arg(long, global = true)]
+    profile: Option<String>,
+    /// AWS region (falls back to the default chain / AWS_REGION).
+    #[arg(long, global = true)]
+    region: Option<String>,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Create a new KMS secp256k1 key + alias and print its Ethereum address.
+    Create {
+        /// Deployment stage, used in the alias + tags (e.g. bot-dev | testnet | production).
+        #[arg(long)]
+        stage: String,
+        /// Role for this key, used in the alias + tags (e.g. beaconator-signer).
+        #[arg(long)]
+        role: String,
+    },
+    /// Print the Ethereum address for an existing key (by alias, key id, or ARN).
+    Address {
+        /// Key identifier: alias (alias/...), key id, or key ARN.
+        #[arg(long)]
+        key: String,
+    },
+}
+
+/// The canonical alias for a (stage, role) KMS key: `alias/perpcity/<stage>/<role>`.
+fn alias_name(stage: &str, role: &str) -> String {
+    format!("alias/perpcity/{stage}/{role}")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    let client = kms_client(cli.profile.as_deref(), cli.region.as_deref()).await;
+
+    match cli.command {
+        Command::Create { stage, role } => create(&client, &stage, &role).await?,
+        Command::Address { key } => println!("{}", derive_address(&client, &key).await?),
+    }
+    Ok(())
+}
+
+/// Build a KMS client from the default AWS chain, optionally overriding profile/region.
+async fn kms_client(profile: Option<&str>, region: Option<&str>) -> Client {
+    let mut loader = aws_config::defaults(BehaviorVersion::latest());
+    if let Some(profile) = profile {
+        loader = loader.profile_name(profile);
+    }
+    if let Some(region) = region {
+        loader = loader.region(aws_config::Region::new(region.to_string()));
+    }
+    Client::new(&loader.load().await)
+}
+
+/// Create a non-exportable secp256k1 signing key, alias it, and print its address.
+async fn create(
+    client: &Client,
+    stage: &str,
+    role: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let alias = alias_name(stage, role);
+
+    let out = client
+        .create_key()
+        .key_spec(KeySpec::EccSecgP256K1)
+        .key_usage(KeyUsageType::SignVerify)
+        .description(format!("perpcity {stage} {role} Ethereum signing key"))
+        .tags(
+            Tag::builder()
+                .tag_key("app")
+                .tag_value("perpcity")
+                .build()?,
+        )
+        .tags(Tag::builder().tag_key("stage").tag_value(stage).build()?)
+        .tags(Tag::builder().tag_key("role").tag_value(role).build()?)
+        .send()
+        .await?;
+
+    let meta = out
+        .key_metadata()
+        .ok_or("CreateKey returned no key metadata")?;
+    let key_id = meta.key_id().to_string();
+    let key_arn = meta.arn().unwrap_or_default().to_string();
+
+    client
+        .create_alias()
+        .alias_name(&alias)
+        .target_key_id(&key_id)
+        .send()
+        .await?;
+
+    let address = derive_address(client, &key_id).await?;
+
+    println!("address:  {address}");
+    println!("alias:    {alias}");
+    println!("key_arn:  {key_arn}");
+    println!("key_id:   {key_id}");
+    Ok(())
+}
+
+/// Derive the Ethereum address for a KMS key. `AwsSigner::new` calls `kms:GetPublicKey`
+/// and computes the address; the private key never leaves KMS.
+async fn derive_address(client: &Client, key: &str) -> Result<Address, Box<dyn std::error::Error>> {
+    let signer = AwsSigner::new(client.clone(), key.to_string(), None).await?;
+    Ok(signer.address())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::alias_name;
+
+    #[test]
+    fn alias_follows_perpcity_convention() {
+        assert_eq!(
+            alias_name("testnet", "beaconator-signer"),
+            "alias/perpcity/testnet/beaconator-signer"
+        );
+        assert_eq!(
+            alias_name("bot-dev", "smoke"),
+            "alias/perpcity/bot-dev/smoke"
+        );
+    }
+}


### PR DESCRIPTION
## What
Adds `kms-wallet`, an operator CLI (`src/bin/kms-wallet.rs`) for AWS KMS secp256k1 signing keys:

- `kms-wallet create --stage <stage> --role <role>` - creates a non-exportable `ECC_SECG_P256K1` / `SIGN_VERIFY` KMS key, aliases it `alias/perpcity/<stage>/<role>`, tags it `{app,stage,role}`, and prints the derived Ethereum **address** (+ alias + key ARN + key id).
- `kms-wallet address --key <alias|id|arn>` - prints the Ethereum address for an existing key.
- `--profile` / `--region` override the default AWS credential chain.

Also enables the shared AWS-signing deps the beaconator KMS refactor will use: alloy `signer-aws` feature + `aws-config` + `aws-sdk-kms` (kept in the same 1.x line as alloy's vendored SDK so the `aws_sdk_kms::Client` type unifies with `AwsSigner`).

## Why
First step of moving bot/service keys off plaintext Secrets Manager onto AWS KMS. The private key is generated **inside KMS and can never be exported** - operators only ever see the address (to fund it) and sign via IAM `kms:Sign`. Address derivation reuses alloy's `AwsSigner` (which calls `kms:GetPublicKey`), guaranteeing the printed address equals what the services will sign as.

## Verification (local, all green)
- `cargo build --bin kms-wallet` - clean.
- `cargo clippy --all-targets --all-features -- -D warnings` - clean.
- `cargo fmt --check` - clean.
- `cargo test --bin kms-wallet` - unit test for the alias convention passes.
- `--help` for the tool + both subcommands renders correctly.
- `make test` (full CI-style suite) - 175 + 20 pass, 0 failures.

Note: creating a real key / deriving an address hits AWS and is validated operationally in the perpcity-bot-dev sandbox (one key + one IAM role) per the rollout plan; no live AWS call is made in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `kms-wallet` CLI for creating AWS KMS-backed, non-exportable secp256k1 Ethereum signing keys.
  * Supports deriving and displaying Ethereum addresses from KMS key identifiers (alias, key ID, or ARN).
  * Includes `create` and `address` subcommands, plus AWS `--profile` and `--region` options.
* **Chores**
  * Updated dependency configuration to enable AWS KMS signing support and add CLI argument parsing.
* **Tests**
  * Added coverage for the KMS alias naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->