### PR TITLE
feat: KMS-backed gas-payer wallet pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,8 @@ Copy `env.example` to `.env.local` (preferred) or `.env` and configure. Required
 RPC_URL=https://arb1.arbitrum.io/rpc          # Arbitrum RPC URL
 ENV=mainnet|testnet|localnet                  # mainnet=Arbitrum One (42161), testnet=Arbitrum Sepolia (421614)
 BEACONATOR_ACCESS_TOKEN=your_secret_token     # API authentication
-PRIVATE_KEY=...                               # Funding wallet private key (no 0x prefix)
-WALLET_PRIVATE_KEYS=...                       # Comma-separated wallet pool keys
+PRIVATE_KEY=...                               # EIP-712 measurement signer key (no 0x prefix); signs only, holds no funds
+WALLET_PRIVATE_KEYS=...                       # Comma-separated pool keys (gas + guest funding transfers; need ETH + testnet USDC)
 PERPCITY_REGISTRY_ADDRESS=0x...               # BeaconRegistry (beacons@v0.0.1)
 PERP_FACTORY_ADDRESS=0x...                    # PerpFactory (perpcity-contracts@v0.1.0)
 ECDSA_VERIFIER_FACTORY_ADDRESS=0x...          # ECDSAVerifierFactory (beacons@v0.0.1)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Create a `.env` file in the project root with the following variables:
 # Arbitrum RPC URL (Arbitrum One mainnet shown; replace with your private endpoint)
 RPC_URL=https://arb1.arbitrum.io/rpc
 
-# Private key for the wallet that will pay for gas (without 0x prefix)
+# Private key for the EIP-712 measurement signer (without 0x prefix). This
+# wallet signs beacon-update digests only — it never holds or sends funds.
+# Gas and guest funding transfers come from the WALLET_PRIVATE_KEYS pool.
 PRIVATE_KEY=your_private_key_here_without_0x_prefix
 
 # Contract addresses (replace with actual deployed contract addresses)

--- a/env.example
+++ b/env.example
@@ -24,10 +24,14 @@ BEACONATOR_ADMIN_TOKEN=your_admin_token_here
 REDIS_URL=redis://127.0.0.1:6379
 
 # Gas-payer wallet pool for sending transactions (beacon creation, perp deployment, etc.)
-# Production (AWS): WALLET_KMS_KEY_IDS - comma-separated KMS key ids / aliases / ARNs.
-# Keys are ECC_SECG_P256K1 SIGN_VERIFY, created via `cargo run --bin kms-wallet -- create`;
-# the private key never leaves KMS and signing needs kms:Sign on the task role.
-# WALLET_KMS_KEY_IDS takes precedence over WALLET_PRIVATE_KEYS when both are set.
+# Production (AWS): keys are ECC_SECG_P256K1 SIGN_VERIFY, created via
+# `cargo run --bin kms-wallet -- create`; the private key never leaves KMS and
+# signing needs kms:Sign on the task role. Precedence when several are set:
+# WALLET_KMS_KEY_IDS > WALLET_KMS_ALIAS_PREFIX > WALLET_PRIVATE_KEYS.
+# Preferred: discover pool keys by alias prefix (kms:ListAliases). Expanding the
+# pool is then `kms-wallet create --role wallet-N` + fund + service restart.
+#WALLET_KMS_ALIAS_PREFIX=alias/perpcity/testnet/wallet-
+# Explicit override: comma-separated KMS key ids / aliases / ARNs.
 #WALLET_KMS_KEY_IDS=alias/perpcity/testnet/wallet-1,alias/perpcity/testnet/wallet-2
 # Dev/CI fallback: comma-separated raw private keys (without 0x prefix).
 WALLET_PRIVATE_KEYS=private_key_1,private_key_2,private_key_3

--- a/env.example
+++ b/env.example
@@ -25,8 +25,9 @@ REDIS_URL=redis://127.0.0.1:6379
 
 # Gas-payer wallet pool for sending transactions (beacon creation, perp deployment, etc.)
 # Production (AWS): keys are ECC_SECG_P256K1 SIGN_VERIFY, created via
-# `cargo run --bin kms-wallet -- create`; the private key never leaves KMS and
-# signing needs kms:Sign on the task role. Precedence when several are set:
+# `cargo run --bin kms-wallet -- create`; the private key never leaves KMS. The
+# task role needs kms:Sign + kms:GetPublicKey (address derivation at startup),
+# plus kms:ListAliases when using WALLET_KMS_ALIAS_PREFIX discovery. Precedence when several are set:
 # WALLET_KMS_KEY_IDS > WALLET_KMS_ALIAS_PREFIX > WALLET_PRIVATE_KEYS.
 # Preferred: discover pool keys by alias prefix (kms:ListAliases). Expanding the
 # pool is then `kms-wallet create --role wallet-N` + fund + service restart.

--- a/env.example
+++ b/env.example
@@ -23,8 +23,13 @@ BEACONATOR_ADMIN_TOKEN=your_admin_token_here
 # Redis URL for wallet pool
 REDIS_URL=redis://127.0.0.1:6379
 
-# Wallet private keys for the pool (comma-separated, without 0x prefix)
-# These wallets are used for sending transactions (beacon creation, perp deployment, etc.)
+# Gas-payer wallet pool for sending transactions (beacon creation, perp deployment, etc.)
+# Production (AWS): WALLET_KMS_KEY_IDS - comma-separated KMS key ids / aliases / ARNs.
+# Keys are ECC_SECG_P256K1 SIGN_VERIFY, created via `cargo run --bin kms-wallet -- create`;
+# the private key never leaves KMS and signing needs kms:Sign on the task role.
+# WALLET_KMS_KEY_IDS takes precedence over WALLET_PRIVATE_KEYS when both are set.
+#WALLET_KMS_KEY_IDS=alias/perpcity/testnet/wallet-1,alias/perpcity/testnet/wallet-2
+# Dev/CI fallback: comma-separated raw private keys (without 0x prefix).
 WALLET_PRIVATE_KEYS=private_key_1,private_key_2,private_key_3
 
 # Optional: Instance ID for wallet locking (auto-generated UUID if not set)

--- a/env.example
+++ b/env.example
@@ -8,8 +8,12 @@ ENV=testnet
 # Recommended: a private endpoint, e.g. https://arb-mainnet.g.alchemy.com/v2/your-api-key
 RPC_URL=https://your-rpc-provider.com/your-api-key
 
-# Private key for the wallet that will pay for gas (without 0x prefix)
-PRIVATE_KEY=your_private_key_here_without_0x_prefix 
+# Private key for the EIP-712 measurement signer (without 0x prefix). This
+# wallet only signs beacon-update digests — it never holds or sends funds.
+# All gas + guest funding transfers go through the WALLET_PRIVATE_KEYS /
+# WALLET_KMS_* pool below, so those wallets need ETH AND testnet USDC for
+# the fund_guest_wallet / fund_bonus_wallet routes.
+PRIVATE_KEY=your_private_key_here_without_0x_prefix
 
 # Sentry DSN
 SENTRY_DSN=https://sentry.

--- a/src/bin/kms-wallet.rs
+++ b/src/bin/kms-wallet.rs
@@ -110,7 +110,10 @@ async fn list(client: &Client, prefix: &str) -> Result<(), Box<dyn std::error::E
             let Some(key_id) = entry.target_key_id() else {
                 continue;
             };
-            let address = derive_address(client, key_id).await?;
+            // Derive via the ALIAS, mirroring how services resolve keys at
+            // startup - alias-scoped IAM (kms:RequestAlias) permits this even
+            // when direct key-id access would be denied.
+            let address = derive_address(client, name).await?;
             println!("{address}  {name}  {key_id}");
             found += 1;
         }

--- a/src/bin/kms-wallet.rs
+++ b/src/bin/kms-wallet.rs
@@ -52,6 +52,12 @@ enum Command {
         #[arg(long)]
         key: String,
     },
+    /// List signing keys by alias prefix, with their Ethereum addresses.
+    List {
+        /// Alias prefix to match.
+        #[arg(long, default_value = "alias/perpcity/")]
+        prefix: String,
+    },
 }
 
 /// The canonical alias for a (stage, role) KMS key: `alias/perpcity/<stage>/<role>`.
@@ -82,6 +88,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Command::Create { stage, role } => create(&client, &stage, &role).await?,
         Command::Address { key } => println!("{}", derive_address(&client, &key).await?),
+        Command::List { prefix } => list(&client, &prefix).await?,
+    }
+    Ok(())
+}
+
+/// List keys whose alias starts with `prefix`, printing address, alias, and
+/// target key id per line. This is the operator view of what services discover
+/// at startup via WALLET_KMS_ALIAS_PREFIX.
+async fn list(client: &Client, prefix: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut found = 0usize;
+    let mut pages = client.list_aliases().into_paginator().send();
+    while let Some(page) = pages.next().await {
+        for entry in page?.aliases() {
+            let Some(name) = entry.alias_name() else {
+                continue;
+            };
+            if !name.starts_with(prefix) {
+                continue;
+            }
+            let Some(key_id) = entry.target_key_id() else {
+                continue;
+            };
+            let address = derive_address(client, key_id).await?;
+            println!("{address}  {name}  {key_id}");
+            found += 1;
+        }
+    }
+    if found == 0 {
+        println!("no keys match prefix {prefix}");
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use alloy::{
     primitives::{Address, Bytes, utils::format_ether},
     providers::Provider,
-    signers::{Signer, local::PrivateKeySigner},
+    signers::{Signer, aws::AwsSigner, local::PrivateKeySigner},
 };
 use rocket::{Build, Rocket};
 use rocket_okapi::{openapi_get_routes_spec, settings::OpenApiSettings};
@@ -22,7 +22,7 @@ use crate::models::{
 use crate::services::beacon::BeaconTypeRegistry;
 use crate::services::beacon::ComponentFactoryRegistry;
 use crate::services::beacon::RecipeRegistry;
-use crate::services::wallet::{WalletManager, WalletSyncService};
+use crate::services::wallet::{PoolSigner, WalletManager, WalletSyncService};
 use rocket::{Request, catch, catchers};
 
 // Provider type with embedded wallet for signing transactions
@@ -442,23 +442,55 @@ pub async fn create_rocket() -> Rocket<Build> {
         }
     }
 
-    // Parse wallet private keys from WALLET_PRIVATE_KEYS env var
-    let wallet_keys_str =
-        env::var("WALLET_PRIVATE_KEYS").expect("WALLET_PRIVATE_KEYS environment variable not set");
-    let wallet_signers: Vec<PrivateKeySigner> = wallet_keys_str
-        .split(',')
-        .map(|k| {
-            k.trim()
-                .parse::<PrivateKeySigner>()
-                .unwrap_or_else(|e| panic!("Invalid private key in WALLET_PRIVATE_KEYS: {e}"))
-                .with_chain_id(Some(chain_id))
-        })
-        .collect();
+    // Build the gas-payer pool signers. Production uses WALLET_KMS_KEY_IDS
+    // (comma-separated KMS key ids / aliases / ARNs); the private key never
+    // leaves KMS. Dev/CI falls back to WALLET_PRIVATE_KEYS (comma-separated raw
+    // keys) when WALLET_KMS_KEY_IDS is unset, so the suite runs without KMS.
+    let pool_signers: Vec<PoolSigner> = if let Ok(kms_ids) = env::var("WALLET_KMS_KEY_IDS") {
+        // aws-config resolves credentials from the standard chain (the ECS task
+        // role on Fargate); one shared KMS client is reused across pool signers.
+        let aws_cfg = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        let kms_client = aws_sdk_kms::Client::new(&aws_cfg);
+        let mut signers = Vec::new();
+        for id in kms_ids.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            let signer = AwsSigner::new(kms_client.clone(), id.to_string(), Some(chain_id))
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("Failed to build AwsSigner for WALLET_KMS_KEY_IDS entry '{id}': {e}")
+                });
+            signers.push(PoolSigner::Kms(signer));
+        }
+        tracing::info!(
+            "Loaded {} wallet signers from WALLET_KMS_KEY_IDS (KMS)",
+            signers.len()
+        );
+        signers
+    } else {
+        let wallet_keys_str = env::var("WALLET_PRIVATE_KEYS").expect(
+            "Either WALLET_KMS_KEY_IDS or WALLET_PRIVATE_KEYS must be set for the wallet pool",
+        );
+        let signers: Vec<PoolSigner> = wallet_keys_str
+            .split(',')
+            .map(|k| {
+                PoolSigner::Local(
+                    k.trim()
+                        .parse::<PrivateKeySigner>()
+                        .unwrap_or_else(|e| {
+                            panic!("Invalid private key in WALLET_PRIVATE_KEYS: {e}")
+                        })
+                        .with_chain_id(Some(chain_id)),
+                )
+            })
+            .collect();
+        tracing::info!(
+            "Loaded {} wallet signers from WALLET_PRIVATE_KEYS (local)",
+            signers.len()
+        );
+        signers
+    };
 
-    tracing::info!(
-        "Loaded {} wallet signers from WALLET_PRIVATE_KEYS",
-        wallet_signers.len()
-    );
+    // Pool addresses, derived once for the Redis sync below (works for both backends).
+    let pool_addresses: Vec<Address> = pool_signers.iter().map(PoolSigner::address).collect();
 
     // Initialize WalletManager (REQUIRED for contract operations)
     let mut wallet_config = WalletManagerConfig::from_env().unwrap_or_else(|e| {
@@ -469,7 +501,7 @@ pub async fn create_rocket() -> Rocket<Build> {
     // Set chain_id from the already-determined chain_id
     wallet_config.chain_id = Some(chain_id);
 
-    let wallet_manager = WalletManager::new(wallet_config, wallet_signers.clone())
+    let wallet_manager = WalletManager::new(wallet_config, pool_signers)
         .await
         .unwrap_or_else(|e| {
             panic!("WalletManager failed to initialize: {e}. Check Redis connectivity.")
@@ -477,8 +509,8 @@ pub async fn create_rocket() -> Rocket<Build> {
 
     tracing::info!("WalletManager initialized for contract operations");
 
-    // Sync local wallet signers to Redis pool on startup
-    let sync_service = WalletSyncService::new(&wallet_signers, wallet_manager.pool());
+    // Sync pool wallet addresses to Redis pool on startup
+    let sync_service = WalletSyncService::new(&pool_addresses, wallet_manager.pool());
     match sync_service.sync().await {
         Ok(result) => {
             tracing::info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,12 +144,20 @@ fn audit_environment() {
     const SECRET_VARS_REQUIRED: &[&str] = &[
         "RPC_URL",
         "PRIVATE_KEY",
-        "WALLET_PRIVATE_KEYS",
         "BEACONATOR_ACCESS_TOKEN",
         "BEACONATOR_ADMIN_TOKEN",
         "REDIS_URL",
     ];
-    const SECRET_VARS_OPTIONAL: &[&str] = &["SENTRY_DSN", "SAFE_TX_SERVICE_URL"];
+    // The wallet pool takes exactly one of WALLET_KMS_KEY_IDS /
+    // WALLET_KMS_ALIAS_PREFIX / WALLET_PRIVATE_KEYS (checked separately below),
+    // so none is individually required.
+    const SECRET_VARS_OPTIONAL: &[&str] = &[
+        "SENTRY_DSN",
+        "SAFE_TX_SERVICE_URL",
+        "WALLET_PRIVATE_KEYS",
+        "WALLET_KMS_KEY_IDS",
+        "WALLET_KMS_ALIAS_PREFIX",
+    ];
     // Other env vars the-beaconator reads. We don't log their values either; we only
     // check presence (for required) and whitespace cleanliness.
     const OTHER_VARS_REQUIRED: &[&str] = &["ENV"];
@@ -253,6 +261,19 @@ fn audit_environment() {
         }
     }
 
+    // Wallet pool source: exactly one of the three vars must be set. (KMS vars
+    // carry key ids/aliases, not secrets, but the pool cannot start without one.)
+    if env::var("WALLET_KMS_KEY_IDS").is_err()
+        && env::var("WALLET_KMS_ALIAS_PREFIX").is_err()
+        && env::var("WALLET_PRIVATE_KEYS").is_err()
+    {
+        tracing::error!(
+            "wallet pool source missing: set one of WALLET_KMS_KEY_IDS, \
+             WALLET_KMS_ALIAS_PREFIX, or WALLET_PRIVATE_KEYS"
+        );
+        problems += 1;
+    }
+
     if problems == 0 {
         tracing::info!("Pre-flight environment audit: all checks passed");
     } else {
@@ -260,6 +281,28 @@ fn audit_environment() {
             "Pre-flight environment audit: {problems} problem(s) detected; startup will likely fail"
         );
     }
+}
+
+/// Discover gas-payer wallet keys by KMS alias prefix (e.g.
+/// "alias/perpcity/testnet/wallet-") via kms:ListAliases. Returns the matching
+/// alias names, sorted for deterministic pool ordering. Aliases without a
+/// target key are skipped. Requires kms:ListAliases on the caller's role.
+async fn discover_wallet_aliases(client: &aws_sdk_kms::Client, prefix: &str) -> Vec<String> {
+    let mut aliases = Vec::new();
+    let mut pages = client.list_aliases().into_paginator().send();
+    while let Some(page) = pages.next().await {
+        let page = page.unwrap_or_else(|e| panic!("kms:ListAliases failed: {e}"));
+        for entry in page.aliases() {
+            let Some(name) = entry.alias_name() else {
+                continue;
+            };
+            if name.starts_with(prefix) && entry.target_key_id().is_some() {
+                aliases.push(name.to_string());
+            }
+        }
+    }
+    aliases.sort();
+    aliases
 }
 
 pub async fn create_rocket() -> Rocket<Build> {
@@ -442,32 +485,58 @@ pub async fn create_rocket() -> Rocket<Build> {
         }
     }
 
-    // Build the gas-payer pool signers. Production uses WALLET_KMS_KEY_IDS
-    // (comma-separated KMS key ids / aliases / ARNs); the private key never
-    // leaves KMS. Dev/CI falls back to WALLET_PRIVATE_KEYS (comma-separated raw
-    // keys) when WALLET_KMS_KEY_IDS is unset, so the suite runs without KMS.
-    let pool_signers: Vec<PoolSigner> = if let Ok(kms_ids) = env::var("WALLET_KMS_KEY_IDS") {
+    // Build the gas-payer pool signers, in precedence order:
+    //   1. WALLET_KMS_KEY_IDS - explicit comma-separated KMS key ids / aliases / ARNs.
+    //   2. WALLET_KMS_ALIAS_PREFIX - discover pool keys by KMS alias prefix
+    //      (e.g. "alias/perpcity/testnet/wallet-") via kms:ListAliases. Expanding
+    //      the pool is then just `kms-wallet create` + fund + service restart:
+    //      no env or IAM change when the grant uses a kms:RequestAlias condition.
+    //   3. WALLET_PRIVATE_KEYS - comma-separated raw keys (dev/CI, no KMS access).
+    // For 1 and 2 the private key never leaves KMS.
+    let explicit_kms_ids = env::var("WALLET_KMS_KEY_IDS").ok();
+    let kms_alias_prefix = env::var("WALLET_KMS_ALIAS_PREFIX").ok();
+    let pool_signers: Vec<PoolSigner> = if explicit_kms_ids.is_some() || kms_alias_prefix.is_some()
+    {
         // aws-config resolves credentials from the standard chain (the ECS task
         // role on Fargate); one shared KMS client is reused across pool signers.
         let aws_cfg = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
         let kms_client = aws_sdk_kms::Client::new(&aws_cfg);
+
+        let (ids, source): (Vec<String>, &str) = if let Some(kms_ids) = explicit_kms_ids {
+            let ids = kms_ids
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect();
+            (ids, "WALLET_KMS_KEY_IDS")
+        } else {
+            let prefix = kms_alias_prefix.unwrap();
+            let ids = discover_wallet_aliases(&kms_client, &prefix).await;
+            if ids.is_empty() {
+                panic!("WALLET_KMS_ALIAS_PREFIX '{prefix}' matched no KMS aliases");
+            }
+            (ids, "WALLET_KMS_ALIAS_PREFIX")
+        };
+
         let mut signers = Vec::new();
-        for id in kms_ids.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-            let signer = AwsSigner::new(kms_client.clone(), id.to_string(), Some(chain_id))
+        for id in &ids {
+            let signer = AwsSigner::new(kms_client.clone(), id.clone(), Some(chain_id))
                 .await
                 .unwrap_or_else(|e| {
-                    panic!("Failed to build AwsSigner for WALLET_KMS_KEY_IDS entry '{id}': {e}")
+                    panic!("Failed to build AwsSigner for {source} entry '{id}': {e}")
                 });
+            tracing::info!("Pool wallet {} <- {id} (KMS)", signer.address());
             signers.push(PoolSigner::Kms(signer));
         }
         tracing::info!(
-            "Loaded {} wallet signers from WALLET_KMS_KEY_IDS (KMS)",
+            "Loaded {} wallet signers from {source} (KMS)",
             signers.len()
         );
         signers
     } else {
         let wallet_keys_str = env::var("WALLET_PRIVATE_KEYS").expect(
-            "Either WALLET_KMS_KEY_IDS or WALLET_PRIVATE_KEYS must be set for the wallet pool",
+            "One of WALLET_KMS_KEY_IDS, WALLET_KMS_ALIAS_PREFIX, or WALLET_PRIVATE_KEYS must be set for the wallet pool",
         );
         let signers: Vec<PoolSigner> = wallet_keys_str
             .split(',')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use alloy::{
-    primitives::{Address, Bytes, utils::format_ether},
-    providers::Provider,
+    primitives::{Address, Bytes},
     signers::{Signer, aws::AwsSigner, local::PrivateKeySigner},
 };
 use rocket::{Build, Rocket};
@@ -456,12 +455,15 @@ pub async fn create_rocket() -> Rocket<Build> {
             .unwrap_or_else(|e| panic!("Failed to build read-only RPC provider: {e}")),
     );
 
-    // Parse the funding wallet private key (ONLY for fund_guest_wallet endpoint)
+    // Parse the measurement signer private key. This signer ONLY signs EIP-712
+    // digests for ECDSA beacon updates — it never holds or sends funds. All
+    // on-chain sends (gas + guest funding transfers) go through the KMS-capable
+    // pool wallets configured below.
     let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY environment variable not set");
 
-    // Get funding wallet address
-    let funding_wallet_address = services::rpc::RpcConfig::get_wallet_address(&private_key)
-        .expect("Failed to get funding wallet address");
+    // Get measurement signer address
+    let signer_address = services::rpc::RpcConfig::get_wallet_address(&private_key)
+        .expect("Failed to get measurement signer address");
 
     // Parse the private key into a signer for ECDSA operations
     let signer = private_key
@@ -469,21 +471,13 @@ pub async fn create_rocket() -> Rocket<Build> {
         .expect("Failed to parse private key into signer")
         .with_chain_id(Some(chain_id));
 
-    // Log funding wallet configuration
-    tracing::info!("Funding wallet configured (for fund_guest_wallet only):");
-    tracing::info!("  - Address: {:?}", funding_wallet_address);
+    // Log measurement signer configuration. No balance check here by design: this
+    // signer holds no funds — the pool wallets carry the float for gas and guest
+    // funding transfers.
+    tracing::info!("Measurement signer configured (EIP-712 signing only, holds no funds):");
+    tracing::info!("  - Address: {:?}", signer_address);
     tracing::info!("  - Chain ID: {:?}", chain_id);
     tracing::info!("  - ENV: {}", env_type);
-
-    // Check funding wallet balance for debugging
-    match read_provider.get_balance(funding_wallet_address).await {
-        Ok(balance) => {
-            tracing::info!("Funding wallet balance: {} ETH", format_ether(balance));
-        }
-        Err(e) => {
-            tracing::warn!("Failed to get funding wallet balance: {}", e);
-        }
-    }
 
     // Build the gas-payer pool signers, in precedence order:
     //   1. WALLET_KMS_KEY_IDS - explicit comma-separated KMS key ids / aliases / ARNs.
@@ -846,7 +840,7 @@ pub async fn create_rocket() -> Rocket<Build> {
         },
         wallets: WalletConfig {
             manager: std::sync::Arc::new(wallet_manager),
-            funding_address: funding_wallet_address,
+            signer_address,
             signer,
             usdc_transfer_limit,
             eth_transfer_limit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,16 +503,26 @@ pub async fn create_rocket() -> Rocket<Build> {
         let kms_client = aws_sdk_kms::Client::new(&aws_cfg);
 
         let (ids, source): (Vec<String>, &str) = if let Some(kms_ids) = explicit_kms_ids {
-            let ids = kms_ids
+            let ids: Vec<String> = kms_ids
                 .split(',')
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(String::from)
                 .collect();
+            // Fail fast on a present-but-blank value ("", ","), which would
+            // otherwise boot the service with an empty wallet pool.
+            if ids.is_empty() {
+                panic!("WALLET_KMS_KEY_IDS is set but contains no usable KMS key ids");
+            }
             (ids, "WALLET_KMS_KEY_IDS")
         } else {
             let prefix = kms_alias_prefix.unwrap();
-            let ids = discover_wallet_aliases(&kms_client, &prefix).await;
+            let prefix = prefix.trim();
+            // A blank prefix would starts_with-match EVERY alias in the account.
+            if prefix.is_empty() {
+                panic!("WALLET_KMS_ALIAS_PREFIX is set but blank");
+            }
+            let ids = discover_wallet_aliases(&kms_client, prefix).await;
             if ids.is_empty() {
                 panic!("WALLET_KMS_ALIAS_PREFIX '{prefix}' matched no KMS aliases");
             }

--- a/src/models/app_state.rs
+++ b/src/models/app_state.rs
@@ -199,7 +199,10 @@ pub struct ProviderConfig {
 #[derive(Clone)]
 pub struct WalletConfig {
     pub manager: Arc<WalletManager>,
-    pub funding_address: Address,
+    /// Address of the PRIVATE_KEY measurement signer. This wallet only signs EIP-712
+    /// digests — it never holds or sends funds. All on-chain sends (gas + guest
+    /// funding transfers) go through the KMS-capable pool wallets instead.
+    pub signer_address: Address,
     /// Signer from PRIVATE_KEY - used for ECDSA beacon signatures.
     /// This wallet's address must match the designated signer configured
     /// in each ECDSA beacon's verifier adapter.

--- a/src/models/wallet.rs
+++ b/src/models/wallet.rs
@@ -113,6 +113,14 @@ impl PrefixedRedisKeys {
         format!("{}wallet_lock:{address}", self.prefix)
     }
 
+    /// Lock key serializing ECDSA updates for one beacon: beacon_update_lock:{beacon}.
+    /// The verifier nonce is per-beacon, so concurrent updates for the same beacon
+    /// race on it (the later-nonced tx can land first and revert the other); this
+    /// lock orders them. Distinct namespace from wallet_lock.
+    pub fn beacon_update_lock(&self, beacon: &Address) -> String {
+        format!("{}beacon_update_lock:{beacon}", self.prefix)
+    }
+
     /// Mapping from beacon address to designated wallet: beacon_wallet:{beacon}
     pub fn beacon_wallet(&self, beacon: &Address) -> String {
         format!("{}beacon_wallet:{beacon}", self.prefix)

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -1,6 +1,5 @@
-use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, U256};
-use alloy::providers::{Provider, ProviderBuilder};
+use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use rocket::serde::json::Json;
 use rocket::{State, http::Status, post};
@@ -163,11 +162,36 @@ pub async fn fund_guest_wallet(
         alloy::primitives::utils::format_ether(U256::from(eth_amount))
     );
 
-    // Check funding wallet ETH balance using read provider
+    // Acquire a pool wallet up front — before any balance checks — so the ETH/USDC
+    // balances we check are the ones that will actually fund the transfer. The
+    // measurement signer (PRIVATE_KEY) never sends funds; all sends go through the
+    // KMS-capable pool. WalletHandle already carries the distributed lock plus a
+    // background heartbeat that extends it, so no separate lock/heartbeat management
+    // is needed here — the wallet stays reserved until `wallet_handle` drops.
+    let wallet_handle = state
+        .wallets
+        .manager
+        .acquire_any_wallet()
+        .await
+        .map_err(|e| {
+            let detailed_error = format!("Failed to acquire pool wallet: {e}");
+            tracing::error!("{}", detailed_error);
+            sentry_error(&hub, "WalletError", detailed_error, vec![]);
+            (
+                Status::ServiceUnavailable,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: "Funding wallet temporarily unavailable".to_string(),
+                }),
+            )
+        })?;
+
+    // Check pool wallet ETH balance using read provider
     let eth_balance = match state
         .provider
         .read_provider
-        .get_balance(state.wallets.funding_address)
+        .get_balance(wallet_handle.address())
         .await
     {
         Ok(balance) => balance,
@@ -189,14 +213,14 @@ pub async fn fund_guest_wallet(
     // Check if we have enough ETH
     if eth_balance < U256::from(eth_amount) {
         tracing::warn!(
-            "Insufficient ETH balance in funding wallet {}. Have: {} ETH, Need: {} ETH",
-            state.wallets.funding_address,
+            "Insufficient ETH balance in pool wallet {}. Have: {} ETH, Need: {} ETH",
+            wallet_handle.address(),
             alloy::primitives::utils::format_ether(eth_balance),
             alloy::primitives::utils::format_ether(U256::from(eth_amount))
         );
         hub.capture_message(
             &format!(
-                "Insufficient ETH balance in funding wallet. Have: {} ETH, Need: {} ETH",
+                "Insufficient ETH balance in pool wallet. Have: {} ETH, Need: {} ETH",
                 alloy::primitives::utils::format_ether(eth_balance),
                 alloy::primitives::utils::format_ether(U256::from(eth_amount))
             ),
@@ -219,7 +243,7 @@ pub async fn fund_guest_wallet(
     // Check USDC balance using read provider
     let usdc_read_contract = IERC20::new(state.contracts.usdc, &*state.provider.read_provider);
     let usdc_balance = match usdc_read_contract
-        .balanceOf(state.wallets.funding_address)
+        .balanceOf(wallet_handle.address())
         .call()
         .await
     {
@@ -242,14 +266,14 @@ pub async fn fund_guest_wallet(
     // Check if we have enough USDC
     if usdc_balance < U256::from(usdc_amount) {
         tracing::warn!(
-            "Insufficient USDC balance in funding wallet {}. Have: {} USDC, Need: {} USDC",
-            state.wallets.funding_address,
+            "Insufficient USDC balance in pool wallet {}. Have: {} USDC, Need: {} USDC",
+            wallet_handle.address(),
             usdc_balance / U256::from(1_000_000),
             usdc_amount / 1_000_000
         );
         hub.capture_message(
             &format!(
-                "Insufficient USDC balance in funding wallet. Have: {} USDC, Need: {} USDC",
+                "Insufficient USDC balance in pool wallet. Have: {} USDC, Need: {} USDC",
                 usdc_balance / U256::from(1_000_000),
                 usdc_amount / 1_000_000
             ),
@@ -269,50 +293,23 @@ pub async fn fund_guest_wallet(
         ));
     }
 
-    // Acquire distributed lock on funding wallet to prevent nonce conflicts
-    // across concurrent requests and multiple beaconator instances
-    let funding_lock = state
-        .wallets
-        .manager
-        .acquire_lock(&state.wallets.funding_address)
-        .await
+    // Build a provider from the pool wallet's signer (local key or KMS, depending on
+    // deployment) to send the two on-chain transfers below.
+    let funding_provider = wallet_handle
+        .build_provider(&state.provider.rpc_url)
         .map_err(|e| {
-            let detailed_error = format!("Failed to acquire funding wallet lock: {e}");
+            let detailed_error = format!("Failed to build funding provider: {e}");
             tracing::error!("{}", detailed_error);
-            sentry_error(&hub, "WalletError", detailed_error, vec![]);
+            sentry_error(&hub, "ConfigError", detailed_error, vec![]);
             (
-                Status::ServiceUnavailable,
+                Status::InternalServerError,
                 Json(ApiResponse {
                     success: false,
                     data: None,
-                    message: "Funding wallet temporarily unavailable".to_string(),
+                    message: "Server RPC configuration is invalid".to_string(),
                 }),
             )
         })?;
-
-    // Keep the lock alive across the two transfer confirmations (up to 2 x 120s,
-    // far longer than the lock TTL). Declared after the lock so it drops first:
-    // the heartbeat is aborted BEFORE the lock is released.
-    let funding_heartbeat = funding_lock.spawn_heartbeat(state.wallets.manager.lock_ttl());
-
-    // Build a fresh provider per-request to avoid stale nonce caching
-    let funding_wallet = EthereumWallet::from(state.wallets.signer.clone());
-    let rpc_url = state.provider.rpc_url.parse().map_err(|e| {
-        let detailed_error = format!("Invalid RPC URL in AppState: {e}");
-        tracing::error!("{}", detailed_error);
-        sentry_error(&hub, "ConfigError", detailed_error, vec![]);
-        (
-            Status::InternalServerError,
-            Json(ApiResponse {
-                success: false,
-                data: None,
-                message: "Server RPC configuration is invalid".to_string(),
-            }),
-        )
-    })?;
-    let funding_provider = ProviderBuilder::new()
-        .wallet(funding_wallet)
-        .connect_http(rpc_url);
 
     // Send ETH using funding provider
     let tx_request = TransactionRequest::default()
@@ -382,8 +379,8 @@ pub async fn fund_guest_wallet(
 
     // The ETH transfer may have taken longer than the lock TTL; abort before the
     // second transaction if the heartbeat observed the lock as lost.
-    if let Err(e) = funding_heartbeat.ensure_held() {
-        let detailed_error = format!("Funding wallet lock lost before USDC transfer: {e}");
+    if let Err(e) = wallet_handle.ensure_lock_held() {
+        let detailed_error = format!("Pool wallet lock lost before USDC transfer: {e}");
         tracing::error!("{}", detailed_error);
         sentry_error(&hub, "WalletError", detailed_error, vec![]);
         return Err((
@@ -564,10 +561,34 @@ pub async fn fund_bonus_wallet(
         usdc_amount / 1_000_000
     );
 
-    // Check funding wallet USDC balance using read provider
+    // Acquire a pool wallet up front — before the balance check — so the USDC balance
+    // we check is the one that will actually fund the transfer. The measurement signer
+    // (PRIVATE_KEY) never sends funds; all sends go through the KMS-capable pool.
+    // WalletHandle already carries the distributed lock plus a background heartbeat
+    // that extends it, so no separate lock/heartbeat management is needed here.
+    let wallet_handle = state
+        .wallets
+        .manager
+        .acquire_any_wallet()
+        .await
+        .map_err(|e| {
+            let detailed_error = format!("Failed to acquire pool wallet: {e}");
+            tracing::error!("{}", detailed_error);
+            sentry_error(&hub, "WalletError", detailed_error, vec![]);
+            (
+                Status::ServiceUnavailable,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: "Funding wallet temporarily unavailable".to_string(),
+                }),
+            )
+        })?;
+
+    // Check pool wallet USDC balance using read provider
     let usdc_read_contract = IERC20::new(state.contracts.usdc, &*state.provider.read_provider);
     let usdc_balance = match usdc_read_contract
-        .balanceOf(state.wallets.funding_address)
+        .balanceOf(wallet_handle.address())
         .call()
         .await
     {
@@ -589,14 +610,14 @@ pub async fn fund_bonus_wallet(
 
     if usdc_balance < U256::from(usdc_amount) {
         tracing::warn!(
-            "Insufficient USDC balance in funding wallet {}. Have: {} USDC, Need: {} USDC",
-            state.wallets.funding_address,
+            "Insufficient USDC balance in pool wallet {}. Have: {} USDC, Need: {} USDC",
+            wallet_handle.address(),
             usdc_balance / U256::from(1_000_000),
             usdc_amount / 1_000_000
         );
         hub.capture_message(
             &format!(
-                "Insufficient USDC balance in bonus funding wallet. Have: {} USDC, Need: {} USDC",
+                "Insufficient USDC balance in bonus pool wallet. Have: {} USDC, Need: {} USDC",
                 usdc_balance / U256::from(1_000_000),
                 usdc_amount / 1_000_000
             ),
@@ -616,53 +637,27 @@ pub async fn fund_bonus_wallet(
         ));
     }
 
-    // Acquire distributed lock on funding wallet to prevent nonce conflicts
-    // across concurrent requests and multiple beaconator instances.
-    let funding_lock = state
-        .wallets
-        .manager
-        .acquire_lock(&state.wallets.funding_address)
-        .await
+    // Build a provider from the pool wallet's signer (local key or KMS, depending on
+    // deployment) to send the transfer below.
+    let funding_provider = wallet_handle
+        .build_provider(&state.provider.rpc_url)
         .map_err(|e| {
-            let detailed_error = format!("Failed to acquire funding wallet lock: {e}");
+            let detailed_error = format!("Failed to build funding provider: {e}");
             tracing::error!("{}", detailed_error);
-            sentry_error(&hub, "WalletError", detailed_error, vec![]);
+            sentry_error(&hub, "ConfigError", detailed_error, vec![]);
             (
-                Status::ServiceUnavailable,
+                Status::InternalServerError,
                 Json(ApiResponse {
                     success: false,
                     data: None,
-                    message: "Funding wallet temporarily unavailable".to_string(),
+                    message: "Server RPC configuration is invalid".to_string(),
                 }),
             )
         })?;
 
-    // Keep the lock alive across the transfer confirmation. Declared after the
-    // lock so it drops first: the heartbeat is aborted BEFORE the lock releases.
-    let funding_heartbeat = funding_lock.spawn_heartbeat(state.wallets.manager.lock_ttl());
-
-    // Build a fresh provider per-request to avoid stale nonce caching.
-    let funding_wallet = EthereumWallet::from(state.wallets.signer.clone());
-    let rpc_url = state.provider.rpc_url.parse().map_err(|e| {
-        let detailed_error = format!("Invalid RPC URL in AppState: {e}");
-        tracing::error!("{}", detailed_error);
-        sentry_error(&hub, "ConfigError", detailed_error, vec![]);
-        (
-            Status::InternalServerError,
-            Json(ApiResponse {
-                success: false,
-                data: None,
-                message: "Server RPC configuration is invalid".to_string(),
-            }),
-        )
-    })?;
-    let funding_provider = ProviderBuilder::new()
-        .wallet(funding_wallet)
-        .connect_http(rpc_url);
-
     // Confirm the lock is still held immediately before submitting.
-    if let Err(e) = funding_heartbeat.ensure_held() {
-        let detailed_error = format!("Funding wallet lock lost before USDC transfer: {e}");
+    if let Err(e) = wallet_handle.ensure_lock_held() {
+        let detailed_error = format!("Pool wallet lock lost before USDC transfer: {e}");
         tracing::error!("{}", detailed_error);
         sentry_error(&hub, "WalletError", detailed_error, vec![]);
         return Err((

--- a/src/services/beacon/ecdsa.rs
+++ b/src/services/beacon/ecdsa.rs
@@ -1,13 +1,58 @@
 use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::providers::Provider;
 use alloy::signers::Signer;
 use alloy::sol_types::SolType;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::time::timeout;
 use tracing;
 
+use crate::ReadOnlyProvider;
 use crate::models::{AppState, UpdateBeaconWithEcdsaRequest};
 use crate::routes::{IBeacon, IEcdsaVerifier};
+use crate::services::wallet::{LockHeartbeat, WalletLockGuard};
+
+/// How long a sent-but-unresolved update tx keeps its beacon lock alive while a
+/// background watcher polls for the receipt, and how often it polls.
+const PENDING_TX_LOCK_GRACE: Duration = Duration::from_secs(240);
+const PENDING_TX_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Keep the per-beacon update lock held while a SENT update tx is still
+/// unresolved, so a second update cannot race it on the verifier nonce. The
+/// lock is released (guard drop) as soon as the tx gets a receipt, or when the
+/// grace window ends; if this instance dies, the lock's Redis TTL expires it.
+fn hold_beacon_lock_until_receipt(
+    lock: (LockHeartbeat, WalletLockGuard),
+    provider: Arc<ReadOnlyProvider>,
+    tx_hash: B256,
+    beacon_address: Address,
+) {
+    tokio::spawn(async move {
+        // Tuple order matches the manager's return: heartbeat drops before the
+        // guard releases when this task ends.
+        let _lock = lock;
+        let deadline = tokio::time::Instant::now() + PENDING_TX_LOCK_GRACE;
+        while tokio::time::Instant::now() < deadline {
+            match provider.get_transaction_receipt(tx_hash).await {
+                Ok(Some(_)) => {
+                    tracing::info!(
+                        "Pending update tx {tx_hash} for beacon {beacon_address} resolved; releasing beacon update lock"
+                    );
+                    return;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!("Receipt poll for pending update tx {tx_hash} failed: {e}");
+                }
+            }
+            tokio::time::sleep(PENDING_TX_POLL_INTERVAL).await;
+        }
+        tracing::warn!(
+            "Releasing beacon {beacon_address} update lock: tx {tx_hash} still unresolved after {PENDING_TX_LOCK_GRACE:?} grace window"
+        );
+    });
+}
 
 /// Outcome of an ECDSA beacon update.
 ///
@@ -105,7 +150,7 @@ pub async fn update_beacon_with_ecdsa(
     // held through receipt-wait so the next update reads post-landing state.
     // Lock order is always beacon -> wallet, so no deadlock is possible; taking
     // the beacon lock first also avoids parking a pool wallet while queued.
-    let _beacon_update_lock = state
+    let beacon_update_lock = state
         .wallets
         .manager
         .acquire_beacon_update_lock(beacon_address)
@@ -276,13 +321,30 @@ pub async fn update_beacon_with_ecdsa(
             receipt
         }
         Ok(Err(e)) => {
+            // The tx WAS sent; the receipt fetch failed but it may still land.
+            // Keep the beacon lock alive in the background so no second update
+            // races the pending one on the verifier nonce.
+            hold_beacon_lock_until_receipt(
+                beacon_update_lock,
+                state.provider.read_provider.clone(),
+                tx_hash,
+                beacon_address,
+            );
             let error_msg = format!("Failed to get transaction receipt: {e}");
             tracing::error!("{}", error_msg);
             return Err(error_msg);
         }
         Err(_) => {
             // The transaction WAS sent; it may still confirm. Report it as
-            // sent-but-unconfirmed so the caller can poll instead of re-sending.
+            // sent-but-unconfirmed so the caller can poll instead of re-sending,
+            // and keep the beacon lock alive until the tx resolves so a retry
+            // cannot race it on the verifier nonce.
+            hold_beacon_lock_until_receipt(
+                beacon_update_lock,
+                state.provider.read_provider.clone(),
+                tx_hash,
+                beacon_address,
+            );
             tracing::warn!(
                 "Timeout waiting for transaction {tx_hash} receipt — returning unconfirmed"
             );

--- a/src/services/beacon/ecdsa.rs
+++ b/src/services/beacon/ecdsa.rs
@@ -26,13 +26,14 @@ pub struct EcdsaUpdateOutcome {
 /// 1. Gets the verifier address from the beacon via `verifier()`
 /// 2. Gets the designated signer from the ECDSAVerifier via `SIGNER()`
 /// 3. Verifies PRIVATE_KEY signer matches designated signer
-/// 4. Acquires any available wallet from pool for transaction sending
-/// 5. Generates a nonce from the current timestamp
-/// 6. Gets the EIP-712 digest from the verifier via `digest(uint256[], uint256)`
-/// 7. Signs the digest with PRIVATE_KEY signer
-/// 8. Packs the signature as r || s || v (65 bytes)
-/// 9. ABI-encodes the inputs as (uint256[] measurement, uint256 nonce)
-/// 10. Calls beacon.update(signature, inputs)
+/// 4. Acquires the per-beacon update lock (serializes verifier-nonce use)
+/// 5. Acquires any available wallet from pool for transaction sending
+/// 6. Generates a nonce from the current timestamp
+/// 7. Gets the EIP-712 digest from the verifier via `digest(uint256[], uint256)`
+/// 8. Signs the digest with PRIVATE_KEY signer
+/// 9. Packs the signature as r || s || v (65 bytes)
+/// 10. ABI-encodes the inputs as (uint256[] measurement, uint256 nonce)
+/// 11. Calls beacon.update(signature, inputs)
 pub async fn update_beacon_with_ecdsa(
     state: &AppState,
     request: UpdateBeaconWithEcdsaRequest,
@@ -98,7 +99,19 @@ pub async fn update_beacon_with_ecdsa(
         beacon_address
     );
 
-    // 4. Acquire any available wallet from pool for sending the transaction
+    // 4. Serialize updates per beacon BEFORE taking a pool wallet: the verifier
+    // nonce is per-beacon, and two in-flight updates (via different gas payers)
+    // can land out of nonce order, reverting the loser on-chain. The guard is
+    // held through receipt-wait so the next update reads post-landing state.
+    // Lock order is always beacon -> wallet, so no deadlock is possible; taking
+    // the beacon lock first also avoids parking a pool wallet while queued.
+    let _beacon_update_lock = state
+        .wallets
+        .manager
+        .acquire_beacon_update_lock(beacon_address)
+        .await?;
+
+    // 5. Acquire any available wallet from pool for sending the transaction
     let wallet_handle = state
         .wallets
         .manager
@@ -117,7 +130,7 @@ pub async fn update_beacon_with_ecdsa(
         .build_provider(&state.provider.rpc_url)
         .map_err(|e| format!("Failed to build provider: {e}"))?;
 
-    // 5. Generate nonce from high-resolution timestamp (nanoseconds) to avoid collisions
+    // 6. Generate nonce from high-resolution timestamp (nanoseconds) to avoid collisions
     let nonce = U256::from(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -127,7 +140,7 @@ pub async fn update_beacon_with_ecdsa(
 
     tracing::info!("Using nonce (timestamp_nanos): {}", nonce);
 
-    // 6. Get EIP-712 digest from verifier (measurement is uint256[])
+    // 7. Get EIP-712 digest from verifier (measurement is uint256[])
     let digest_raw = verifier
         .digest(measurement_array.clone(), nonce)
         .call()
@@ -137,7 +150,7 @@ pub async fn update_beacon_with_ecdsa(
 
     tracing::info!("Got EIP-712 digest: {:?}", digest);
 
-    // 7. Sign the digest with PRIVATE_KEY signer (state.wallets.signer)
+    // 8. Sign the digest with PRIVATE_KEY signer (state.wallets.signer)
     let signature = state
         .wallets
         .signer
@@ -147,7 +160,7 @@ pub async fn update_beacon_with_ecdsa(
 
     tracing::info!("Signed digest successfully");
 
-    // 8. Pack signature as r || s || v (65 bytes)
+    // 9. Pack signature as r || s || v (65 bytes)
     // Alloy signature.as_bytes() returns [r (32 bytes) | s (32 bytes) | v (1 byte)]
     let sig_bytes = Bytes::from(signature.as_bytes().to_vec());
 
@@ -165,7 +178,7 @@ pub async fn update_beacon_with_ecdsa(
         signature.s()
     );
 
-    // 9. ABI-encode inputs as (uint256[] measurement, uint256 nonce)
+    // 10. ABI-encode inputs as (uint256[] measurement, uint256 nonce)
     // Use abi_encode_params to match Solidity's abi.encode(uint256[], uint256)
     let inputs = <(
         alloy::sol_types::sol_data::Array<alloy::sol_types::sol_data::Uint<256>>,
@@ -186,7 +199,7 @@ pub async fn update_beacon_with_ecdsa(
         nonce
     );
 
-    // 10. Simulate the update call first to get revert reason if it would fail
+    // 11. Simulate the update call first to get revert reason if it would fail
     let beacon_write = IBeacon::new(beacon_address, &provider);
     match beacon_write
         .update(sig_bytes.clone(), inputs_bytes.clone())
@@ -239,7 +252,7 @@ pub async fn update_beacon_with_ecdsa(
         }
     }
 
-    // 11. Send the actual transaction
+    // 12. Send the actual transaction
     tracing::info!(
         "Sending update transaction to beacon with wallet {}",
         tx_wallet_address
@@ -256,7 +269,7 @@ pub async fn update_beacon_with_ecdsa(
     let tx_hash = *pending_tx.tx_hash();
     tracing::info!("Transaction hash: {:?}", tx_hash);
 
-    // 12. Wait for confirmation with timeout
+    // 13. Wait for confirmation with timeout
     let receipt = match timeout(Duration::from_secs(60), pending_tx.get_receipt()).await {
         Ok(Ok(receipt)) => {
             tracing::info!("Transaction confirmed via get_receipt()");
@@ -284,7 +297,7 @@ pub async fn update_beacon_with_ecdsa(
         }
     };
 
-    // 13. Validate transaction status
+    // 14. Validate transaction status
     if !receipt.status() {
         let error_msg = format!("update() transaction {tx_hash} reverted (status: false)");
         tracing::error!("{}", error_msg);
@@ -293,7 +306,7 @@ pub async fn update_beacon_with_ecdsa(
         return Err(error_msg);
     }
 
-    // 14. Validate IndexUpdated event was emitted
+    // 15. Validate IndexUpdated event was emitted
     let index_updated_found = receipt.inner.logs().iter().any(|log| {
         // IndexUpdated event signature: keccak256("IndexUpdated(uint256)")
         log.address() == beacon_address

--- a/src/services/beacon/ecdsa.rs
+++ b/src/services/beacon/ecdsa.rs
@@ -17,6 +17,9 @@ use crate::services::wallet::{LockHeartbeat, WalletLockGuard};
 /// background watcher polls for the receipt, and how often it polls.
 const PENDING_TX_LOCK_GRACE: Duration = Duration::from_secs(240);
 const PENDING_TX_POLL_INTERVAL: Duration = Duration::from_secs(3);
+/// Per-poll RPC timeout so one hung request cannot stall the watcher loop
+/// (deadline is only checked between polls).
+const PENDING_TX_POLL_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Keep the per-beacon update lock held while a SENT update tx is still
 /// unresolved, so a second update cannot race it on the verifier nonce. The
@@ -34,16 +37,26 @@ fn hold_beacon_lock_until_receipt(
         let _lock = lock;
         let deadline = tokio::time::Instant::now() + PENDING_TX_LOCK_GRACE;
         while tokio::time::Instant::now() < deadline {
-            match provider.get_transaction_receipt(tx_hash).await {
-                Ok(Some(_)) => {
+            match timeout(
+                PENDING_TX_POLL_TIMEOUT,
+                provider.get_transaction_receipt(tx_hash),
+            )
+            .await
+            {
+                Ok(Ok(Some(_))) => {
                     tracing::info!(
                         "Pending update tx {tx_hash} for beacon {beacon_address} resolved; releasing beacon update lock"
                     );
                     return;
                 }
-                Ok(None) => {}
-                Err(e) => {
+                Ok(Ok(None)) => {}
+                Ok(Err(e)) => {
                     tracing::warn!("Receipt poll for pending update tx {tx_hash} failed: {e}");
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "Receipt poll for pending update tx {tx_hash} timed out after {PENDING_TX_POLL_TIMEOUT:?}"
+                    );
                 }
             }
             tokio::time::sleep(PENDING_TX_POLL_INTERVAL).await;
@@ -323,16 +336,21 @@ pub async fn update_beacon_with_ecdsa(
         Ok(Err(e)) => {
             // The tx WAS sent; the receipt fetch failed but it may still land.
             // Keep the beacon lock alive in the background so no second update
-            // races the pending one on the verifier nonce.
+            // races the pending one on the verifier nonce, and return the hash
+            // as sent-but-unconfirmed so the caller polls instead of re-sending.
             hold_beacon_lock_until_receipt(
                 beacon_update_lock,
                 state.provider.read_provider.clone(),
                 tx_hash,
                 beacon_address,
             );
-            let error_msg = format!("Failed to get transaction receipt: {e}");
-            tracing::error!("{}", error_msg);
-            return Err(error_msg);
+            tracing::error!(
+                "Failed to get receipt for sent update tx {tx_hash}: {e} - returning unconfirmed"
+            );
+            return Ok(EcdsaUpdateOutcome {
+                tx_hash,
+                confirmed: false,
+            });
         }
         Err(_) => {
             // The transaction WAS sent; it may still confirm. Report it as

--- a/src/services/wallet/lock.rs
+++ b/src/services/wallet/lock.rs
@@ -76,6 +76,26 @@ impl WalletLock {
         }
     }
 
+    /// Create a lock that serializes ECDSA updates for one BEACON (the locked
+    /// address is the beacon, not a pool wallet). Same acquire/heartbeat/release
+    /// semantics as a wallet lock, distinct Redis key namespace.
+    pub fn for_beacon_update(
+        conn: ConnectionManager,
+        beacon_address: Address,
+        instance_id: String,
+        ttl: Duration,
+        keys: &PrefixedRedisKeys,
+    ) -> Self {
+        let lock_key = keys.beacon_update_lock(&beacon_address);
+        Self {
+            conn,
+            wallet_address: beacon_address,
+            instance_id,
+            lock_key,
+            ttl,
+        }
+    }
+
     /// Get a Redis connection (cheap clone of the shared auto-reconnecting manager)
     fn get_conn(&self) -> ConnectionManager {
         self.conn.clone()
@@ -461,6 +481,76 @@ mod tests {
         ConnectionManager::new(client)
             .await
             .expect("Failed to connect to Redis")
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis"]
+    async fn test_beacon_update_lock_serializes_per_beacon() {
+        let test_prefix = format!("test-{}:", uuid::Uuid::new_v4());
+        let keys = PrefixedRedisKeys::new(&test_prefix);
+        let conn = test_conn().await;
+
+        let beacon_a = Address::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        let beacon_b = Address::from_str("0x2222222222222222222222222222222222222222").unwrap();
+        let ttl = Duration::from_secs(10);
+
+        let lock_a = WalletLock::for_beacon_update(
+            conn.clone(),
+            beacon_a,
+            "instance-1".to_string(),
+            ttl,
+            &keys,
+        );
+        let guard_a = lock_a
+            .acquire(1, Duration::from_millis(50))
+            .await
+            .expect("first acquire for beacon A should succeed");
+
+        // A second updater (different instance) must NOT get the same beacon.
+        let lock_a2 = WalletLock::for_beacon_update(
+            conn.clone(),
+            beacon_a,
+            "instance-2".to_string(),
+            ttl,
+            &keys,
+        );
+        assert!(
+            lock_a2.try_acquire().await.is_err(),
+            "concurrent update for the same beacon must be blocked"
+        );
+
+        // A DIFFERENT beacon is independent.
+        let lock_b = WalletLock::for_beacon_update(
+            conn.clone(),
+            beacon_b,
+            "instance-2".to_string(),
+            ttl,
+            &keys,
+        );
+        let guard_b = lock_b
+            .try_acquire()
+            .await
+            .expect("different beacon must not be blocked");
+
+        // The beacon namespace must not collide with the wallet lock for the
+        // same address (a beacon lock must never block a pool-wallet lock).
+        let wallet_lock_same_addr =
+            WalletLock::with_keys(conn.clone(), beacon_a, "instance-3".to_string(), ttl, &keys);
+        let guard_w = wallet_lock_same_addr
+            .try_acquire()
+            .await
+            .expect("wallet lock namespace must be independent of beacon locks");
+
+        guard_a.release().await.expect("release A");
+        guard_b.release().await.expect("release B");
+        guard_w.release().await.expect("release W");
+
+        // After release, the beacon is acquirable again.
+        let guard_a2 = lock_a2
+            .try_acquire()
+            .await
+            .expect("beacon lock must be acquirable after release");
+        guard_a2.release().await.expect("release A2");
     }
 
     #[tokio::test]

--- a/src/services/wallet/manager.rs
+++ b/src/services/wallet/manager.rs
@@ -154,7 +154,7 @@ pub struct WalletManager {
 }
 
 impl WalletManager {
-    /// Create a new WalletManager with local private key signers
+    /// Create a new WalletManager with pool signers (local key or KMS backed)
     ///
     /// # Arguments
     /// * `config` - Configuration for the wallet manager

--- a/src/services/wallet/manager.rs
+++ b/src/services/wallet/manager.rs
@@ -309,6 +309,36 @@ impl WalletManager {
         ))
     }
 
+    /// Serialize ECDSA updates for one beacon across all beaconator instances.
+    ///
+    /// The verifier nonce is per-beacon: two in-flight updates for the same
+    /// beacon can land out of nonce order and the loser reverts on-chain. Hold
+    /// the returned guard from nonce generation through receipt so updates for
+    /// a beacon are strictly ordered. Field order in the tuple mirrors
+    /// `WalletHandle`: the heartbeat is dropped before the guard releases.
+    pub async fn acquire_beacon_update_lock(
+        &self,
+        beacon: Address,
+    ) -> Result<(LockHeartbeat, WalletLockGuard), String> {
+        let pool = self.require_pool();
+        let config = self.require_config();
+
+        let lock = WalletLock::for_beacon_update(
+            pool.connection().clone(),
+            beacon,
+            pool.instance_id().to_string(),
+            config.lock_ttl,
+            pool.keys(),
+        );
+
+        let guard = lock
+            .acquire(config.lock_retry_count, config.lock_retry_delay)
+            .await
+            .map_err(|e| format!("Failed to acquire beacon update lock for {beacon}: {e}"))?;
+        let heartbeat = guard.spawn_heartbeat(config.lock_ttl);
+        Ok((heartbeat, guard))
+    }
+
     /// Acquire any available wallet from the pool
     ///
     /// First pass tries every wallet once without retrying (so one busy wallet

--- a/src/services/wallet/manager.rs
+++ b/src/services/wallet/manager.rs
@@ -11,15 +11,52 @@ use super::{WalletLock, WalletLockGuard, WalletPool};
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, B256};
 use alloy::providers::ProviderBuilder;
+use alloy::signers::aws::AwsSigner;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::{Error as SignerError, Signature, Signer};
 
 use crate::AlloyProvider;
 use crate::models::wallet::{WalletInfo, WalletManagerConfig};
 
-/// Local private key signer wrapper
+/// A gas-payer pool signer: either a local private key (dev/CI) or an AWS KMS
+/// key (production). The pool is keyed by Ethereum address regardless of backend.
 #[derive(Clone)]
-pub struct WalletSigner(PrivateKeySigner);
+pub enum PoolSigner {
+    /// Local secp256k1 private key held in memory.
+    Local(PrivateKeySigner),
+    /// AWS KMS `ECC_SECG_P256K1` key; the private key never leaves KMS.
+    Kms(AwsSigner),
+}
+
+impl PoolSigner {
+    /// The Ethereum address of this signer (cached at construction for KMS).
+    pub fn address(&self) -> Address {
+        match self {
+            PoolSigner::Local(s) => s.address(),
+            PoolSigner::Kms(s) => s.address(),
+        }
+    }
+
+    /// Sign a 32-byte hash with the underlying backend.
+    pub async fn sign_hash(&self, hash: &B256) -> Result<Signature, SignerError> {
+        match self {
+            PoolSigner::Local(s) => s.sign_hash(hash).await,
+            PoolSigner::Kms(s) => s.sign_hash(hash).await,
+        }
+    }
+
+    /// Wrap this signer into an `EthereumWallet` for transaction sending.
+    fn ethereum_wallet(&self) -> EthereumWallet {
+        match self {
+            PoolSigner::Local(s) => EthereumWallet::from(s.clone()),
+            PoolSigner::Kms(s) => EthereumWallet::from(s.clone()),
+        }
+    }
+}
+
+/// Pool signer wrapper (local key or KMS).
+#[derive(Clone)]
+pub struct WalletSigner(PoolSigner);
 
 impl WalletSigner {
     /// Get the address of the signer
@@ -87,7 +124,7 @@ impl WalletHandle {
     /// # Returns
     /// An AlloyProvider configured with this wallet's signer
     pub fn build_provider(&self, rpc_url: &str) -> Result<AlloyProvider, String> {
-        let wallet = EthereumWallet::from(self.signer.0.clone());
+        let wallet = self.signer.0.ethereum_wallet();
 
         let provider = ProviderBuilder::new().wallet(wallet).connect_http(
             rpc_url
@@ -112,8 +149,8 @@ pub struct WalletManager {
     config: Option<WalletManagerConfig>,
     /// Whether this is a test stub that will panic on use
     is_test_stub: bool,
-    /// Local private key signers keyed by address
-    signers: HashMap<Address, PrivateKeySigner>,
+    /// Pool signers (local key or KMS) keyed by address
+    signers: HashMap<Address, PoolSigner>,
 }
 
 impl WalletManager {
@@ -121,10 +158,10 @@ impl WalletManager {
     ///
     /// # Arguments
     /// * `config` - Configuration for the wallet manager
-    /// * `signers` - Local private key signers for the wallet pool
+    /// * `signers` - Pool signers (local key or KMS) for the wallet pool
     pub async fn new(
         config: WalletManagerConfig,
-        signers: Vec<PrivateKeySigner>,
+        signers: Vec<PoolSigner>,
     ) -> Result<Self, String> {
         let instance_id = config
             .instance_id
@@ -133,7 +170,7 @@ impl WalletManager {
 
         let pool = WalletPool::new(&config.redis_url, instance_id).await?;
 
-        let signers_map: HashMap<Address, PrivateKeySigner> =
+        let signers_map: HashMap<Address, PoolSigner> =
             signers.into_iter().map(|s| (s.address(), s)).collect();
 
         Ok(Self {
@@ -177,8 +214,10 @@ impl WalletManager {
         let instance_id = format!("test-{}", uuid::Uuid::new_v4());
         let pool = WalletPool::with_prefix(redis_url, instance_id, prefix).await?;
 
-        let signers_map: HashMap<Address, PrivateKeySigner> =
-            signers.into_iter().map(|s| (s.address(), s)).collect();
+        let signers_map: HashMap<Address, PoolSigner> = signers
+            .into_iter()
+            .map(|s| (s.address(), PoolSigner::Local(s)))
+            .collect();
 
         Ok(Self {
             pool: Some(pool),

--- a/src/services/wallet/mod.rs
+++ b/src/services/wallet/mod.rs
@@ -12,7 +12,7 @@ pub mod pool;
 pub mod sync;
 
 pub use lock::{LockHeartbeat, WalletLock, WalletLockGuard};
-pub use manager::{WalletHandle, WalletManager, WalletSigner};
+pub use manager::{PoolSigner, WalletHandle, WalletManager, WalletSigner};
 pub use mock::{MockWalletHandle, MockWalletManager};
 pub use pool::WalletPool;
 pub use sync::{SyncResult, WalletSyncService};

--- a/src/services/wallet/sync.rs
+++ b/src/services/wallet/sync.rs
@@ -1,25 +1,25 @@
 //! Wallet sync service for syncing local wallets to Redis pool
 //!
-//! This module provides [`WalletSyncService`] which synchronizes wallets from
-//! local private key signers to the Redis wallet pool. It handles adding new
-//! wallets while preserving existing wallet state (status and designated beacons).
+//! This module provides [`WalletSyncService`] which synchronizes the pool wallet
+//! addresses (local key or KMS backed) to the Redis wallet pool. It handles
+//! adding new wallets while preserving existing wallet state (status and
+//! designated beacons).
 //!
 //! # Example
 //!
 //! ```rust,ignore
 //! use the_beaconator::services::wallet::{WalletPool, WalletSyncService};
-//! use alloy::signers::local::PrivateKeySigner;
+//! use alloy::primitives::Address;
 //!
-//! let signers: Vec<PrivateKeySigner> = vec![/* ... */];
+//! let addresses: Vec<Address> = vec![/* ... */];
 //! let pool = WalletPool::new("redis://localhost:6379", "instance-1").await?;
-//! let sync_service = WalletSyncService::new(&signers, &pool);
+//! let sync_service = WalletSyncService::new(&addresses, &pool);
 //!
 //! let result = sync_service.sync().await?;
 //! println!("Added {} wallets, {} unchanged", result.added.len(), result.unchanged.len());
 //! ```
 
 use alloy::primitives::Address;
-use alloy::signers::local::PrivateKeySigner;
 
 use crate::models::wallet::{WalletInfo, WalletStatus};
 use crate::services::wallet::WalletPool;
@@ -177,9 +177,9 @@ impl SyncResult {
     }
 }
 
-/// Service for syncing local wallet signers to Redis pool
+/// Service for syncing pool wallet addresses to Redis pool
 pub struct WalletSyncService<'a> {
-    signers: &'a [PrivateKeySigner],
+    addresses: &'a [Address],
     pool: &'a WalletPool,
 }
 
@@ -188,10 +188,10 @@ impl<'a> WalletSyncService<'a> {
     ///
     /// # Arguments
     ///
-    /// * `signers` - Local private key signers to sync to the pool
+    /// * `addresses` - Pool wallet addresses to sync to the pool
     /// * `pool` - Reference to Redis wallet pool for storage
-    pub fn new(signers: &'a [PrivateKeySigner], pool: &'a WalletPool) -> Self {
-        Self { signers, pool }
+    pub fn new(addresses: &'a [Address], pool: &'a WalletPool) -> Self {
+        Self { addresses, pool }
     }
 
     /// Sync local wallet signers to the Redis pool
@@ -210,8 +210,7 @@ impl<'a> WalletSyncService<'a> {
 
         let mut result = SyncResult::new();
 
-        for signer in self.signers {
-            let address = signer.address();
+        for &address in self.addresses {
             let key_id = format!("{address}");
 
             match self.sync_single_wallet(address, key_id).await {

--- a/tests/integration_tests/register_beacon_integration_tests.rs
+++ b/tests/integration_tests/register_beacon_integration_tests.rs
@@ -269,7 +269,7 @@ async fn test_registration_error_handling() {
             "Zero beacon address",
         ),
         (
-            app_state.wallets.funding_address,
+            app_state.wallets.signer_address,
             Address::ZERO,
             "Zero registry address",
         ),

--- a/tests/integration_tests/wallet_test.rs
+++ b/tests/integration_tests/wallet_test.rs
@@ -169,13 +169,13 @@ mod tests {
         let (app_state, _anvil) = create_isolated_test_app_state().await;
 
         // Verify test setup
-        assert_ne!(app_state.wallets.funding_address, Address::ZERO);
+        assert_ne!(app_state.wallets.signer_address, Address::ZERO);
         assert_ne!(app_state.contracts.usdc, Address::ZERO);
 
         // Check that we can get the balance (even if it's zero)
         let balance_result = TestUtils::get_balance(
             &app_state.provider.read_provider,
-            app_state.wallets.funding_address,
+            app_state.wallets.signer_address,
         )
         .await;
         assert!(balance_result.is_ok());

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -45,7 +45,7 @@ async fn test_with_different_account() {
     let app_state = create_test_app_state_with_account(1).await;
 
     // This account has different address but same balance
-    assert_ne!(app_state.wallets.funding_address, Address::ZERO);
+    assert_ne!(app_state.wallets.signer_address, Address::ZERO);
 }
 ```
 
@@ -59,7 +59,7 @@ async fn test_blockchain_operations() {
     let app_state = create_test_app_state().await;
 
     // Check balance
-    let balance = TestUtils::get_balance(&app_state.provider.read_provider, app_state.wallets.funding_address).await?;
+    let balance = TestUtils::get_balance(&app_state.provider.read_provider, app_state.wallets.signer_address).await?;
     assert!(balance > U256::ZERO);
 
     // Get block number
@@ -564,7 +564,7 @@ pub async fn create_test_app_state() -> AppState {
         },
         wallets: WalletConfig {
             manager: Arc::new(WalletManager::test_stub()),
-            funding_address: deployment.deployer,
+            signer_address: deployment.deployer,
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
@@ -633,7 +633,7 @@ pub async fn create_isolated_test_app_state() -> (AppState, AnvilManager) {
         },
         wallets: WalletConfig {
             manager: create_test_wallet_manager().await,
-            funding_address: deployment.deployer,
+            signer_address: deployment.deployer,
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
@@ -727,7 +727,7 @@ pub async fn create_isolated_test_app_state_with_redis() -> (AppState, AnvilMana
         },
         wallets: WalletConfig {
             manager: wallet_manager,
-            funding_address: deployment.deployer,
+            signer_address: deployment.deployer,
             signer: test_signer,
             usdc_transfer_limit: 1_000_000_000,
             eth_transfer_limit: 10_000_000_000_000_000,
@@ -793,7 +793,7 @@ pub async fn create_test_app_state_with_account(account_index: usize) -> AppStat
         },
         wallets: WalletConfig {
             manager: Arc::new(WalletManager::test_stub()),
-            funding_address: anvil.accounts[account_index],
+            signer_address: anvil.accounts[account_index],
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
             eth_transfer_limit: 10_000_000_000_000_000, // 0.01 ETH
@@ -908,7 +908,7 @@ pub async fn create_simple_test_app_state() -> AppState {
         },
         wallets: WalletConfig {
             manager: wallet_manager,
-            funding_address: Address::from_str("0x1111111111111111111111111111111111111111")
+            signer_address: Address::from_str("0x1111111111111111111111111111111111111111")
                 .unwrap(),
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
@@ -974,7 +974,7 @@ pub async fn create_test_app_state_with_provider(
         },
         wallets: WalletConfig {
             manager: wallet_manager,
-            funding_address: Address::from_str("0x1111111111111111111111111111111111111111")
+            signer_address: Address::from_str("0x1111111111111111111111111111111111111111")
                 .unwrap(),
             signer,
             usdc_transfer_limit: 1_000_000_000, // 1000 USDC
@@ -1061,7 +1061,7 @@ mod tests {
     async fn test_app_state_creation() {
         #[allow(deprecated)]
         let app_state = create_test_app_state().await;
-        assert_ne!(app_state.wallets.funding_address, Address::ZERO);
+        assert_ne!(app_state.wallets.signer_address, Address::ZERO);
         assert_ne!(app_state.contracts.ecdsa_verifier_factory, Address::ZERO);
         assert_ne!(app_state.contracts.perp_factory, Address::ZERO);
     }
@@ -1091,7 +1091,7 @@ mod tests {
         // Test balance
         let balance = TestUtils::get_balance(
             &app_state.provider.read_provider,
-            app_state.wallets.funding_address,
+            app_state.wallets.signer_address,
         )
         .await;
         assert!(balance.is_ok());

--- a/tests/unit_tests/wallet_route_tests.rs
+++ b/tests/unit_tests/wallet_route_tests.rs
@@ -169,6 +169,7 @@ async fn test_fund_wallet_eth_exceeds_limit() {
 }
 
 #[tokio::test]
+#[ignore = "requires WalletManager with Redis"]
 async fn test_fund_wallet_zero_amounts() {
     let test_state = create_test_state().await;
     let state = State::from(&test_state);
@@ -187,6 +188,7 @@ async fn test_fund_wallet_zero_amounts() {
 }
 
 #[tokio::test]
+#[ignore = "requires WalletManager with Redis"]
 async fn test_fund_wallet_valid_format_network_failure() {
     let test_state = create_test_state().await;
     let state = State::from(&test_state);
@@ -240,6 +242,7 @@ async fn test_fund_wallet_scientific_notation() {
 }
 
 #[tokio::test]
+#[ignore = "requires WalletManager with Redis"]
 async fn test_fund_wallet_address_with_mixed_case() {
     let test_state = create_test_state().await;
     let state = State::from(&test_state);
@@ -320,6 +323,7 @@ async fn test_fund_wallet_disabled_on_unknown_production_chain() {
 }
 
 #[tokio::test]
+#[ignore = "requires WalletManager with Redis"]
 async fn test_fund_wallet_allowed_on_arbitrum_sepolia() {
     // chain_id 421614 = Arbitrum Sepolia. Guardrail must NOT fire — we should fall through
     // to the normal handler and (with the test stub provider) bottom out somewhere later.


### PR DESCRIPTION
## What
Moves the gas-payer wallet POOL onto AWS KMS signing, keeping the EIP-712 measurement signer as a local key:

- New env var `WALLET_KMS_KEY_IDS` (comma-separated KMS key ids / aliases / ARNs). Each entry becomes an alloy `AwsSigner` built at startup from one shared `aws_sdk_kms::Client` (creds via the default chain - the ECS task role on Fargate). The address is derived via `kms:GetPublicKey` and cached; the private key never leaves KMS.
- `PoolSigner { Local(PrivateKeySigner), Kms(AwsSigner) }` in `services/wallet/manager.rs`; the pool, Redis sync, and per-address locking are unchanged (still keyed by `Address`). `WalletHandle::build_provider` wraps either backend into an `EthereumWallet`.
- **Fallback preserved:** when `WALLET_KMS_KEY_IDS` is unset, `WALLET_PRIVATE_KEYS` behaves exactly as before - dev and CI run without KMS access.
- `WalletSyncService` now takes addresses (backend-agnostic) instead of `PrivateKeySigner`s.
- `env.example` documents the new variable.

## Intentionally unchanged
`PRIVATE_KEY` (the EIP-712 measurement signer) stays a LOCAL key: its address is bound on-chain in each beacon's ECDSAVerifier, so moving it to KMS would force market recreation. The measurement-signing path in `services/beacon/ecdsa.rs` is untouched.

## Follow-up (separate PR, perpcity-client repo)
`sst.config.ts`: drop `WALLET_PRIVATE_KEYS` from the Beaconator `ssm:` block, set `WALLET_KMS_KEY_IDS` in `environment:`, and attach a RolePolicy granting the Beaconator task role `kms:Sign` + `kms:GetPublicKey` on the pool key ARNs (keys created out-of-band via the `kms-wallet` CLI from #72).

## Verification (local, all green)
- `cargo build` - clean.
- `cargo clippy --all-targets --all-features -- -D warnings` - clean.
- `cargo fmt --check` - clean.
- `make test` (full CI-style suite) - 175 + 20 pass, 0 failures, via the local-key fallback (no KMS in CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pool signing support for both local private keys and AWS KMS keys, including deterministic alias discovery and key-id precedence.
  * Added `kms-wallet list --prefix` to enumerate matching KMS keys by alias prefix.
  * Added per-beacon update locking to serialize beacon verifier nonce updates.
* **Documentation**
  * Updated guidance for EIP-712 measurement-signer keys and wallet-pool configuration; clarified Dev/CI notes.
* **Bug Fixes**
  * Updated wallet sync and guest/bonus funding routes to operate using configured pool wallet addresses and lock checks.
  * Improved beacon ECDSA update flow to hold locks through receipt waiting and handle timeouts as sent-but-unconfirmed.  
* **Refactor**
  * Updated wallet identity field to `signer_address` and adjusted related wiring/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->