### PR TITLE
feat: wallet pool resilience and balance-aware selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ alloy = { version = "2.1", features = ["full", "node-bindings", "signer-aws"] }
 # signer-aws depends on so the `aws_sdk_kms::Client` type unifies with AwsSigner.
 aws-config = "1"
 aws-sdk-kms = "1"
+# Best-effort PutMetricData for pool wallet ETH/USDC balances (src/services/wallet/balances.rs).
+# Kept in the same 1.x line as aws-sdk-kms; publish failures never abort startup or requests.
+aws-sdk-cloudwatch = "1"
 # CLI arg parsing for the kms-wallet operator binary (src/bin/kms-wallet.rs).
 clap = { version = "4", features = ["derive"] }
 dotenvy = "0.15.7"

--- a/env.example
+++ b/env.example
@@ -44,6 +44,15 @@ WALLET_PRIVATE_KEYS=private_key_1,private_key_2,private_key_3
 # Optional: Instance ID for wallet locking (auto-generated UUID if not set)
 # BEACONATOR_INSTANCE_ID=instance-1
 
+# Optional: Wallet pool balance sweep (see src/services/wallet/balances.rs).
+# A background task periodically refreshes cached ETH/USDC balances for every
+# pool wallet: below WALLET_MIN_ETH_WEI it logs a warning ("fund it") and
+# selection proactively skips that wallet instead of sending through it and
+# failing; both metrics are also published to CloudWatch (namespace PerpCity)
+# best-effort (silently skipped without AWS credentials, e.g. local dev).
+# WALLET_MIN_ETH_WEI=500000000000000    # 0.0005 ETH (default)
+# WALLET_BALANCE_SWEEP_SECS=60          # seconds between sweeps (default)
+
 # Contract addresses (replace with actual deployed contract addresses)
 # Pinned to: beacons@v0.0.1, perpcity-contracts@v0.1.0 — see .contracts-versions
 PERPCITY_REGISTRY_ADDRESS=0x3456789012345678901234567890123456789012

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use crate::models::{
 use crate::services::beacon::BeaconTypeRegistry;
 use crate::services::beacon::ComponentFactoryRegistry;
 use crate::services::beacon::RecipeRegistry;
-use crate::services::wallet::{PoolSigner, WalletManager, WalletSyncService};
+use crate::services::wallet::{BalanceTracker, PoolSigner, WalletManager, WalletSyncService};
 use rocket::{Request, catch, catchers};
 
 // Provider type with embedded wallet for signing transactions
@@ -170,6 +170,11 @@ fn audit_environment() {
         // JSON map of component factory addresses seeded into Redis at startup
         // (set by the AWS deployment; see perpcity-client/sst.config.ts)
         "COMPONENT_FACTORIES_JSON",
+        // Wallet pool balance sweep (src/services/wallet/balances.rs): ETH floor
+        // (wei) below which a pool wallet is flagged + skipped by proactive
+        // selection, and how often the sweep refreshes cached balances.
+        "WALLET_MIN_ETH_WEI",
+        "WALLET_BALANCE_SWEEP_SECS",
     ];
 
     let mut problems = 0usize;
@@ -574,13 +579,29 @@ pub async fn create_rocket() -> Rocket<Build> {
     // Set chain_id from the already-determined chain_id
     wallet_config.chain_id = Some(chain_id);
 
-    let wallet_manager = WalletManager::new(wallet_config, pool_signers)
+    let mut wallet_manager = WalletManager::new(wallet_config, pool_signers)
         .await
         .unwrap_or_else(|e| {
             panic!("WalletManager failed to initialize: {e}. Check Redis connectivity.")
         });
 
     tracing::info!("WalletManager initialized for contract operations");
+
+    // Balance tracker: periodically refreshes cached ETH/USDC balances for the
+    // pool so selection can proactively skip a wallet under the ETH floor and
+    // funding routes can order by cached USDC, plus emits per-wallet CloudWatch
+    // metrics. Attach it to the manager BEFORE it's shared behind the AppState
+    // Arc below — selection reads it through that Arc from then on.
+    let balance_tracker =
+        std::sync::Arc::new(BalanceTracker::new(read_provider.clone(), usdc_address));
+    wallet_manager.set_balance_tracker(std::sync::Arc::clone(&balance_tracker));
+    let balance_sweep_interval = BalanceTracker::sweep_interval_from_env();
+    balance_tracker.spawn_sweep(pool_addresses.clone(), balance_sweep_interval);
+    tracing::info!(
+        "Wallet balance sweep started (interval {:?}, {} wallet(s))",
+        balance_sweep_interval,
+        pool_addresses.len()
+    );
 
     // Sync pool wallet addresses to Redis pool on startup
     let sync_service = WalletSyncService::new(&pool_addresses, wallet_manager.pool());

--- a/src/models/wallet.rs
+++ b/src/models/wallet.rs
@@ -113,6 +113,13 @@ impl PrefixedRedisKeys {
         format!("{}wallet_lock:{address}", self.prefix)
     }
 
+    /// ZSET tracking least-recently-used wallet selection order: wallet_lru.
+    /// Score is the millisecond timestamp of the wallet's last successful
+    /// acquisition; members absent from the set (never acquired) sort first.
+    pub fn wallet_lru(&self) -> String {
+        format!("{}wallet_lru", self.prefix)
+    }
+
     /// Lock key serializing ECDSA updates for one beacon: beacon_update_lock:{beacon}.
     /// The verifier nonce is per-beacon, so concurrent updates for the same beacon
     /// race on it (the later-nonced tx can land first and revert the other); this

--- a/src/routes/wallet.rs
+++ b/src/routes/wallet.rs
@@ -162,136 +162,161 @@ pub async fn fund_guest_wallet(
         alloy::primitives::utils::format_ether(U256::from(eth_amount))
     );
 
-    // Acquire a pool wallet up front — before any balance checks — so the ETH/USDC
-    // balances we check are the ones that will actually fund the transfer. The
-    // measurement signer (PRIVATE_KEY) never sends funds; all sends go through the
-    // KMS-capable pool. WalletHandle already carries the distributed lock plus a
-    // background heartbeat that extends it, so no separate lock/heartbeat management
-    // is needed here — the wallet stays reserved until `wallet_handle` drops.
-    let wallet_handle = state
-        .wallets
-        .manager
-        .acquire_any_wallet()
-        .await
-        .map_err(|e| {
-            let detailed_error = format!("Failed to acquire pool wallet: {e}");
-            tracing::error!("{}", detailed_error);
-            sentry_error(&hub, "WalletError", detailed_error, vec![]);
-            (
-                Status::ServiceUnavailable,
-                Json(ApiResponse {
-                    success: false,
-                    data: None,
-                    message: "Funding wallet temporarily unavailable".to_string(),
-                }),
-            )
-        })?;
+    // Acquire a pool wallet and verify it has both funds — before any transfer — so
+    // the ETH/USDC balances we check are the ones that will actually fund the
+    // transfer. The measurement signer (PRIVATE_KEY) never sends funds; all sends go
+    // through the KMS-capable pool. WalletHandle already carries the distributed lock
+    // plus a background heartbeat that extends it, so no separate lock/heartbeat
+    // management is needed here — the wallet stays reserved until `wallet_handle`
+    // drops.
+    //
+    // Selection is a bounded loop over the pool (one attempt per wallet, at most):
+    // `acquire_wallet_for_usdc` orders candidates by cached USDC balance descending
+    // (spreading drain across the pool instead of always hitting the same wallet —
+    // see the 2026-06-30 testnet freeze), then this fresh on-chain check verifies
+    // that cache (which can be up to one sweep interval stale). A wallet that fails
+    // either check is excluded and the next candidate is tried; only once every
+    // wallet in the pool has been tried does this return the insufficient-balance
+    // error below.
+    let max_wallet_attempts = state.wallets.manager.signer_addresses().len().max(1);
+    let mut excluded_wallets: std::collections::HashSet<Address> = std::collections::HashSet::new();
+    let mut wallet_handle = None;
 
-    // Check pool wallet ETH balance using read provider
-    let eth_balance = match state
-        .provider
-        .read_provider
-        .get_balance(wallet_handle.address())
-        .await
-    {
-        Ok(balance) => balance,
-        Err(e) => {
-            let detailed_error = format!("Failed to get ETH balance: {e}");
-            tracing::error!("{}", detailed_error);
-            sentry_error(&hub, "RpcError", detailed_error, vec![]);
-            return Err((
-                Status::InternalServerError,
-                Json(ApiResponse {
-                    success: false,
-                    data: None,
-                    message: "Failed to retrieve ETH balance".to_string(),
-                }),
-            ));
-        }
-    };
+    for attempt in 1..=max_wallet_attempts {
+        let handle = state
+            .wallets
+            .manager
+            .acquire_wallet_for_usdc(U256::from(usdc_amount), &excluded_wallets)
+            .await
+            .map_err(|e| {
+                let detailed_error = format!("Failed to acquire pool wallet: {e}");
+                tracing::error!("{}", detailed_error);
+                sentry_error(&hub, "WalletError", detailed_error, vec![]);
+                (
+                    Status::ServiceUnavailable,
+                    Json(ApiResponse {
+                        success: false,
+                        data: None,
+                        message: "Funding wallet temporarily unavailable".to_string(),
+                    }),
+                )
+            })?;
+        let candidate = handle.address();
+        let last_attempt = attempt == max_wallet_attempts;
 
-    // Check if we have enough ETH
-    if eth_balance < U256::from(eth_amount) {
-        tracing::warn!(
-            "Insufficient ETH balance in pool wallet {}. Have: {} ETH, Need: {} ETH",
-            wallet_handle.address(),
-            alloy::primitives::utils::format_ether(eth_balance),
-            alloy::primitives::utils::format_ether(U256::from(eth_amount))
-        );
-        hub.capture_message(
-            &format!(
-                "Insufficient ETH balance in pool wallet. Have: {} ETH, Need: {} ETH",
+        // Check pool wallet ETH balance using read provider
+        let eth_balance = match state.provider.read_provider.get_balance(candidate).await {
+            Ok(balance) => balance,
+            Err(e) => {
+                let detailed_error = format!("Failed to get ETH balance: {e}");
+                tracing::error!("{}", detailed_error);
+                sentry_error(&hub, "RpcError", detailed_error, vec![]);
+                return Err((
+                    Status::InternalServerError,
+                    Json(ApiResponse {
+                        success: false,
+                        data: None,
+                        message: "Failed to retrieve ETH balance".to_string(),
+                    }),
+                ));
+            }
+        };
+
+        // Check if we have enough ETH
+        if eth_balance < U256::from(eth_amount) {
+            tracing::warn!(
+                "Insufficient ETH balance in pool wallet {}. Have: {} ETH, Need: {} ETH",
+                candidate,
                 alloy::primitives::utils::format_ether(eth_balance),
                 alloy::primitives::utils::format_ether(U256::from(eth_amount))
-            ),
-            sentry::Level::Warning,
-        );
-        return Err((
-            Status::InternalServerError,
-            Json(ApiResponse {
-                success: false,
-                data: None,
-                message: format!(
-                    "Insufficient ETH balance. Have: {} ETH, Need: {} ETH",
+            );
+            if !last_attempt {
+                excluded_wallets.insert(candidate);
+                drop(handle);
+                continue;
+            }
+            hub.capture_message(
+                &format!(
+                    "Insufficient ETH balance in pool wallet. Have: {} ETH, Need: {} ETH",
                     alloy::primitives::utils::format_ether(eth_balance),
                     alloy::primitives::utils::format_ether(U256::from(eth_amount))
                 ),
-            }),
-        ));
-    }
-
-    // Check USDC balance using read provider
-    let usdc_read_contract = IERC20::new(state.contracts.usdc, &*state.provider.read_provider);
-    let usdc_balance = match usdc_read_contract
-        .balanceOf(wallet_handle.address())
-        .call()
-        .await
-    {
-        Ok(result) => result,
-        Err(e) => {
-            let detailed_error = format!("Failed to get USDC balance: {e}");
-            tracing::error!("{}", detailed_error);
-            sentry_error(&hub, "RpcError", detailed_error, vec![]);
+                sentry::Level::Warning,
+            );
             return Err((
                 Status::InternalServerError,
                 Json(ApiResponse {
                     success: false,
                     data: None,
-                    message: "Failed to retrieve USDC balance".to_string(),
+                    message: format!(
+                        "Insufficient ETH balance. Have: {} ETH, Need: {} ETH",
+                        alloy::primitives::utils::format_ether(eth_balance),
+                        alloy::primitives::utils::format_ether(U256::from(eth_amount))
+                    ),
                 }),
             ));
         }
-    };
 
-    // Check if we have enough USDC
-    if usdc_balance < U256::from(usdc_amount) {
-        tracing::warn!(
-            "Insufficient USDC balance in pool wallet {}. Have: {} USDC, Need: {} USDC",
-            wallet_handle.address(),
-            usdc_balance / U256::from(1_000_000),
-            usdc_amount / 1_000_000
-        );
-        hub.capture_message(
-            &format!(
-                "Insufficient USDC balance in pool wallet. Have: {} USDC, Need: {} USDC",
+        // Check USDC balance using read provider
+        let usdc_read_contract = IERC20::new(state.contracts.usdc, &*state.provider.read_provider);
+        let usdc_balance = match usdc_read_contract.balanceOf(candidate).call().await {
+            Ok(result) => result,
+            Err(e) => {
+                let detailed_error = format!("Failed to get USDC balance: {e}");
+                tracing::error!("{}", detailed_error);
+                sentry_error(&hub, "RpcError", detailed_error, vec![]);
+                return Err((
+                    Status::InternalServerError,
+                    Json(ApiResponse {
+                        success: false,
+                        data: None,
+                        message: "Failed to retrieve USDC balance".to_string(),
+                    }),
+                ));
+            }
+        };
+
+        // Check if we have enough USDC
+        if usdc_balance < U256::from(usdc_amount) {
+            tracing::warn!(
+                "Insufficient USDC balance in pool wallet {}. Have: {} USDC, Need: {} USDC",
+                candidate,
                 usdc_balance / U256::from(1_000_000),
                 usdc_amount / 1_000_000
-            ),
-            sentry::Level::Warning,
-        );
-        return Err((
-            Status::InternalServerError,
-            Json(ApiResponse {
-                success: false,
-                data: None,
-                message: format!(
-                    "Insufficient USDC balance. Have: {} USDC, Need: {} USDC",
-                    usdc_balance / U256::from(1_000_000), // Convert to human readable
+            );
+            if !last_attempt {
+                excluded_wallets.insert(candidate);
+                drop(handle);
+                continue;
+            }
+            hub.capture_message(
+                &format!(
+                    "Insufficient USDC balance in pool wallet. Have: {} USDC, Need: {} USDC",
+                    usdc_balance / U256::from(1_000_000),
                     usdc_amount / 1_000_000
                 ),
-            }),
-        ));
+                sentry::Level::Warning,
+            );
+            return Err((
+                Status::InternalServerError,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    message: format!(
+                        "Insufficient USDC balance. Have: {} USDC, Need: {} USDC",
+                        usdc_balance / U256::from(1_000_000), // Convert to human readable
+                        usdc_amount / 1_000_000
+                    ),
+                }),
+            ));
+        }
+
+        wallet_handle = Some(handle);
+        break;
     }
+
+    let wallet_handle =
+        wallet_handle.expect("balance-check retry loop must return or break with a wallet handle");
 
     // Build a provider from the pool wallet's signer (local key or KMS, depending on
     // deployment) to send the two on-chain transfers below.
@@ -561,81 +586,102 @@ pub async fn fund_bonus_wallet(
         usdc_amount / 1_000_000
     );
 
-    // Acquire a pool wallet up front — before the balance check — so the USDC balance
-    // we check is the one that will actually fund the transfer. The measurement signer
-    // (PRIVATE_KEY) never sends funds; all sends go through the KMS-capable pool.
-    // WalletHandle already carries the distributed lock plus a background heartbeat
-    // that extends it, so no separate lock/heartbeat management is needed here.
-    let wallet_handle = state
-        .wallets
-        .manager
-        .acquire_any_wallet()
-        .await
-        .map_err(|e| {
-            let detailed_error = format!("Failed to acquire pool wallet: {e}");
-            tracing::error!("{}", detailed_error);
-            sentry_error(&hub, "WalletError", detailed_error, vec![]);
-            (
-                Status::ServiceUnavailable,
-                Json(ApiResponse {
-                    success: false,
-                    data: None,
-                    message: "Funding wallet temporarily unavailable".to_string(),
-                }),
-            )
-        })?;
+    // Acquire a pool wallet and verify its USDC balance — before the transfer — so
+    // the balance we check is the one that will actually fund it. The measurement
+    // signer (PRIVATE_KEY) never sends funds; all sends go through the KMS-capable
+    // pool. WalletHandle already carries the distributed lock plus a background
+    // heartbeat that extends it, so no separate lock/heartbeat management is needed
+    // here.
+    //
+    // Same bounded-loop selection as `fund_guest_wallet`: `acquire_wallet_for_usdc`
+    // orders candidates by cached USDC descending to spread drain across the pool,
+    // this fresh on-chain check verifies the (possibly stale) cache, and a wallet
+    // that fails it is excluded in favor of the next candidate.
+    let max_wallet_attempts = state.wallets.manager.signer_addresses().len().max(1);
+    let mut excluded_wallets: std::collections::HashSet<Address> = std::collections::HashSet::new();
+    let mut wallet_handle = None;
 
-    // Check pool wallet USDC balance using read provider
-    let usdc_read_contract = IERC20::new(state.contracts.usdc, &*state.provider.read_provider);
-    let usdc_balance = match usdc_read_contract
-        .balanceOf(wallet_handle.address())
-        .call()
-        .await
-    {
-        Ok(result) => result,
-        Err(e) => {
-            let detailed_error = format!("Failed to get USDC balance: {e}");
-            tracing::error!("{}", detailed_error);
-            sentry_error(&hub, "RpcError", detailed_error, vec![]);
+    for attempt in 1..=max_wallet_attempts {
+        let handle = state
+            .wallets
+            .manager
+            .acquire_wallet_for_usdc(U256::from(usdc_amount), &excluded_wallets)
+            .await
+            .map_err(|e| {
+                let detailed_error = format!("Failed to acquire pool wallet: {e}");
+                tracing::error!("{}", detailed_error);
+                sentry_error(&hub, "WalletError", detailed_error, vec![]);
+                (
+                    Status::ServiceUnavailable,
+                    Json(ApiResponse {
+                        success: false,
+                        data: None,
+                        message: "Funding wallet temporarily unavailable".to_string(),
+                    }),
+                )
+            })?;
+        let candidate = handle.address();
+        let last_attempt = attempt == max_wallet_attempts;
+
+        // Check pool wallet USDC balance using read provider
+        let usdc_read_contract = IERC20::new(state.contracts.usdc, &*state.provider.read_provider);
+        let usdc_balance = match usdc_read_contract.balanceOf(candidate).call().await {
+            Ok(result) => result,
+            Err(e) => {
+                let detailed_error = format!("Failed to get USDC balance: {e}");
+                tracing::error!("{}", detailed_error);
+                sentry_error(&hub, "RpcError", detailed_error, vec![]);
+                return Err((
+                    Status::InternalServerError,
+                    Json(ApiResponse {
+                        success: false,
+                        data: None,
+                        message: "Failed to retrieve USDC balance".to_string(),
+                    }),
+                ));
+            }
+        };
+
+        if usdc_balance < U256::from(usdc_amount) {
+            tracing::warn!(
+                "Insufficient USDC balance in pool wallet {}. Have: {} USDC, Need: {} USDC",
+                candidate,
+                usdc_balance / U256::from(1_000_000),
+                usdc_amount / 1_000_000
+            );
+            if !last_attempt {
+                excluded_wallets.insert(candidate);
+                drop(handle);
+                continue;
+            }
+            hub.capture_message(
+                &format!(
+                    "Insufficient USDC balance in bonus pool wallet. Have: {} USDC, Need: {} USDC",
+                    usdc_balance / U256::from(1_000_000),
+                    usdc_amount / 1_000_000
+                ),
+                sentry::Level::Warning,
+            );
             return Err((
                 Status::InternalServerError,
                 Json(ApiResponse {
                     success: false,
                     data: None,
-                    message: "Failed to retrieve USDC balance".to_string(),
+                    message: format!(
+                        "Insufficient USDC balance. Have: {} USDC, Need: {} USDC",
+                        usdc_balance / U256::from(1_000_000),
+                        usdc_amount / 1_000_000
+                    ),
                 }),
             ));
         }
-    };
 
-    if usdc_balance < U256::from(usdc_amount) {
-        tracing::warn!(
-            "Insufficient USDC balance in pool wallet {}. Have: {} USDC, Need: {} USDC",
-            wallet_handle.address(),
-            usdc_balance / U256::from(1_000_000),
-            usdc_amount / 1_000_000
-        );
-        hub.capture_message(
-            &format!(
-                "Insufficient USDC balance in bonus pool wallet. Have: {} USDC, Need: {} USDC",
-                usdc_balance / U256::from(1_000_000),
-                usdc_amount / 1_000_000
-            ),
-            sentry::Level::Warning,
-        );
-        return Err((
-            Status::InternalServerError,
-            Json(ApiResponse {
-                success: false,
-                data: None,
-                message: format!(
-                    "Insufficient USDC balance. Have: {} USDC, Need: {} USDC",
-                    usdc_balance / U256::from(1_000_000),
-                    usdc_amount / 1_000_000
-                ),
-            }),
-        ));
+        wallet_handle = Some(handle);
+        break;
     }
+
+    let wallet_handle =
+        wallet_handle.expect("balance-check retry loop must return or break with a wallet handle");
 
     // Build a provider from the pool wallet's signer (local key or KMS, depending on
     // deployment) to send the transfer below.

--- a/src/services/beacon/ecdsa.rs
+++ b/src/services/beacon/ecdsa.rs
@@ -11,7 +11,8 @@ use tracing;
 use crate::ReadOnlyProvider;
 use crate::models::{AppState, UpdateBeaconWithEcdsaRequest};
 use crate::routes::{IBeacon, IEcdsaVerifier};
-use crate::services::wallet::{LockHeartbeat, WalletLockGuard};
+use crate::services::transaction::execution::is_insufficient_funds_error;
+use crate::services::wallet::{LockHeartbeat, WalletHandle, WalletLockGuard};
 
 /// How long a sent-but-unresolved update tx keeps its beacon lock alive while a
 /// background watcher polls for the receipt, and how often it polls.
@@ -169,24 +170,14 @@ pub async fn update_beacon_with_ecdsa(
         .acquire_beacon_update_lock(beacon_address)
         .await?;
 
-    // 5. Acquire any available wallet from pool for sending the transaction
-    let wallet_handle = state
-        .wallets
-        .manager
-        .acquire_any_wallet()
-        .await
-        .map_err(|e| format!("Failed to acquire wallet for transaction: {e}"))?;
-
-    let tx_wallet_address = wallet_handle.address();
-    tracing::info!(
-        "Using wallet {} from pool to send transaction (gas payer)",
-        tx_wallet_address
-    );
-
-    // Build provider with the acquired wallet for sending transactions
-    let provider = wallet_handle
-        .build_provider(&state.provider.rpc_url)
-        .map_err(|e| format!("Failed to build provider: {e}"))?;
+    // 5. Bounded retry budget for wallet acquisition: one attempt per pool
+    // wallet at most (floor 1). A wallet that turns out to be drained of gas
+    // (insufficient funds on preflight or send, see step 11/12) is excluded
+    // and a different one is tried instead of failing the whole update — this
+    // is what stops a single drained wallet from freezing every update, as
+    // happened on 2026-06-30 when selection had no such fallback.
+    let max_wallet_attempts = state.wallets.manager.signer_addresses().len().max(1);
+    let mut excluded_wallets: std::collections::HashSet<Address> = std::collections::HashSet::new();
 
     // 6. Generate nonce from high-resolution timestamp (nanoseconds) to avoid collisions
     let nonce = U256::from(
@@ -257,19 +248,43 @@ pub async fn update_beacon_with_ecdsa(
         nonce
     );
 
-    // 11. Simulate the update call first to get revert reason if it would fail
-    let beacon_write = IBeacon::new(beacon_address, &provider);
-    match beacon_write
-        .update(sig_bytes.clone(), inputs_bytes.clone())
-        .call()
-        .await
-    {
-        Ok(_) => {
-            tracing::info!("Preflight simulation of beacon.update() succeeded");
-        }
-        Err(e) => {
+    // 11 + 12. Acquire a wallet, simulate, and send — retrying with a
+    // different (excluded) wallet on an insufficient-funds error from either
+    // step. Any other error returns immediately, exactly as before this loop
+    // existed. The lock guarding one wallet is dropped before the next
+    // attempt acquires a different one; the per-beacon `beacon_update_lock`
+    // stays held across every attempt (it was acquired before this loop, in
+    // step 4, and spans the whole function).
+    let mut wallet_handle: Option<WalletHandle> = None;
+    let mut pending_tx = None;
+
+    for attempt in 1..=max_wallet_attempts {
+        let handle = state
+            .wallets
+            .manager
+            .acquire_any_wallet_excluding(&excluded_wallets)
+            .await
+            .map_err(|e| format!("Failed to acquire wallet for transaction: {e}"))?;
+        let attempt_address = handle.address();
+        tracing::info!(
+            "Using wallet {} from pool to send transaction (gas payer) [attempt {attempt}/{max_wallet_attempts}]",
+            attempt_address
+        );
+
+        // Build provider with the acquired wallet for sending transactions
+        let provider = handle
+            .build_provider(&state.provider.rpc_url)
+            .map_err(|e| format!("Failed to build provider: {e}"))?;
+
+        // 11. Simulate the update call first to get revert reason if it would fail
+        let beacon_write = IBeacon::new(beacon_address, &provider);
+        if let Err(e) = beacon_write
+            .update(sig_bytes.clone(), inputs_bytes.clone())
+            .call()
+            .await
+        {
             // Only run diagnostics for EVM reverts, not transport/network failures
-            if e.as_revert_data().is_some() {
+            let error_msg = if e.as_revert_data().is_some() {
                 let diag_timeout = Duration::from_secs(5);
 
                 let verify_detail = match timeout(
@@ -294,33 +309,69 @@ pub async fn update_beacon_with_ecdsa(
                         Err(_) => "usedProofs diagnostic timed out".to_string(),
                     };
 
-                let error_msg = format!(
+                format!(
                     "Preflight simulation of beacon.update() reverted: {e}. \
                      Verifier diagnostics: {verify_detail}. {used_detail}"
+                )
+            } else {
+                // Transport or other non-revert error: fail fast without diagnostics
+                format!("Preflight simulation of beacon.update() failed (transport/RPC): {e}")
+            };
+            tracing::error!("{}", error_msg);
+
+            if is_insufficient_funds_error(&error_msg) && attempt < max_wallet_attempts {
+                tracing::warn!(
+                    "Wallet {attempt_address} appears out of gas (preflight simulation failed with \
+                     insufficient funds); excluding it and retrying with a different pool wallet"
                 );
-                tracing::error!("{}", error_msg);
+                excluded_wallets.insert(attempt_address);
+                drop(handle);
+                continue;
+            }
+            return Err(error_msg);
+        }
+        tracing::info!("Preflight simulation of beacon.update() succeeded");
+
+        // 12. Send the actual transaction
+        tracing::info!(
+            "Sending update transaction to beacon with wallet {}",
+            attempt_address
+        );
+        handle.ensure_lock_held()?;
+        match beacon_write
+            .update(sig_bytes.clone(), inputs_bytes.clone())
+            .send()
+            .await
+        {
+            Ok(pt) => {
+                pending_tx = Some(pt);
+                wallet_handle = Some(handle);
+                break;
+            }
+            Err(e) => {
+                let error_msg = format!("Failed to send update transaction: {e}");
+                if is_insufficient_funds_error(&error_msg) && attempt < max_wallet_attempts {
+                    tracing::warn!(
+                        "Wallet {attempt_address} appears out of gas (send failed with \
+                         insufficient funds); excluding it and retrying with a different pool wallet"
+                    );
+                    excluded_wallets.insert(attempt_address);
+                    drop(handle);
+                    continue;
+                }
                 return Err(error_msg);
             }
-
-            // Transport or other non-revert error: fail fast without diagnostics
-            let error_msg =
-                format!("Preflight simulation of beacon.update() failed (transport/RPC): {e}");
-            tracing::error!("{}", error_msg);
-            return Err(error_msg);
         }
     }
 
-    // 12. Send the actual transaction
-    tracing::info!(
-        "Sending update transaction to beacon with wallet {}",
-        tx_wallet_address
-    );
-    wallet_handle.ensure_lock_held()?;
-    let pending_tx = beacon_write
-        .update(sig_bytes.clone(), inputs_bytes.clone())
-        .send()
-        .await
-        .map_err(|e| format!("Failed to send update transaction: {e}"))?;
+    // The loop above always either returns early or `break`s with both `Some`.
+    // `_wallet_handle` is intentionally never read again: its only remaining
+    // job is to keep the winning wallet's distributed lock held (via Drop)
+    // for the rest of this function, exactly like the un-looped version did.
+    let _wallet_handle = wallet_handle
+        .expect("acquire/simulate/send retry loop must return or break with a wallet handle");
+    let pending_tx = pending_tx
+        .expect("acquire/simulate/send retry loop must return or break with a pending tx");
 
     tracing::info!("Transaction sent, waiting for receipt...");
 

--- a/src/services/transaction/execution.rs
+++ b/src/services/transaction/execution.rs
@@ -27,4 +27,23 @@ pub fn is_nonce_error(error_msg: &str) -> bool {
         || error_lower.contains("replacement tx underpriced")
 }
 
+/// Detect insufficient-funds errors from error messages
+///
+/// This helper function checks if an error message indicates the sending wallet
+/// does not have enough native gas token to cover the transaction. A drained
+/// pool wallet triggers this on send or preflight simulation; the caller can
+/// use it to retry with a different wallet instead of failing the request.
+///
+/// # Arguments
+/// * `error_msg` - The error message to check
+///
+/// # Returns
+/// `true` if the error indicates insufficient funds, `false` otherwise
+pub fn is_insufficient_funds_error(error_msg: &str) -> bool {
+    let error_lower = error_msg.to_lowercase();
+    error_lower.contains("insufficient funds")
+        || error_lower.contains("insufficient balance for transfer")
+        || error_lower.contains("gas required exceeds allowance")
+}
+
 // Tests moved to tests/unit_tests/transaction_execution_tests.rs

--- a/src/services/wallet/balances.rs
+++ b/src/services/wallet/balances.rs
@@ -282,8 +282,9 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_default_eth_floor_when_env_unset() {
-        // SAFETY: single-threaded test, no concurrent env access in this test binary segment.
+        // SAFETY: #[serial] guarantees no concurrent env access from other tests.
         unsafe {
             std::env::remove_var("WALLET_MIN_ETH_WEI");
         }

--- a/src/services/wallet/balances.rs
+++ b/src/services/wallet/balances.rs
@@ -1,0 +1,299 @@
+//! Proactive balance tracking for the gas-payer wallet pool
+//!
+//! On 2026-06-30 a single drained testnet pool wallet froze the entire beacon
+//! update fleet: selection picked purely by lock status (never balance), so
+//! ~90% of acquisitions kept landing on the empty wallet and every send
+//! failed with no retry. `BalanceTracker` closes that gap two ways:
+//!   - a background sweep periodically refreshes cached ETH/USDC balances and
+//!     emits a CloudWatch metric per wallet, plus a warning log when a wallet
+//!     drops below the ETH floor (visibility before it's a fire);
+//!   - `WalletManager` selection consults the cache to skip a wallet that is
+//!     already known to be under the floor, without ever blocking the
+//!     acquisition hot path on a fresh RPC call.
+//!
+//! The cache can be stale (up to one sweep interval): callers that need a
+//! guarantee (funding routes) still do a fresh on-chain check after
+//! acquisition. This tracker is a proactive optimization, not a source of
+//! truth.
+
+use alloy::primitives::{Address, U256};
+use alloy::providers::Provider;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use crate::ReadOnlyProvider;
+use crate::routes::IERC20;
+
+/// Default ETH floor (wei) below which a pool wallet is flagged and skipped
+/// by proactive selection: 0.0005 ETH.
+const DEFAULT_MIN_ETH_WEI: u128 = 500_000_000_000_000;
+/// Default interval between balance sweeps.
+const DEFAULT_SWEEP_SECS: u64 = 60;
+
+/// Cached ETH + USDC balances for one pool wallet.
+#[derive(Debug, Clone, Copy)]
+pub struct WalletBalances {
+    pub eth: U256,
+    pub usdc: U256,
+    pub fetched_at: Instant,
+}
+
+/// Periodically refreshed balance cache for the gas-payer pool.
+pub struct BalanceTracker {
+    provider: Arc<ReadOnlyProvider>,
+    usdc: Address,
+    eth_floor: U256,
+    balances: RwLock<HashMap<Address, WalletBalances>>,
+}
+
+impl BalanceTracker {
+    /// Create a tracker with the ETH floor read from `WALLET_MIN_ETH_WEI`
+    /// (falls back to 0.0005 ETH if unset or unparseable).
+    pub fn new(provider: Arc<ReadOnlyProvider>, usdc: Address) -> Self {
+        Self {
+            provider,
+            usdc,
+            eth_floor: Self::eth_floor_from_env(),
+            balances: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn eth_floor_from_env() -> U256 {
+        std::env::var("WALLET_MIN_ETH_WEI")
+            .ok()
+            .and_then(|v| v.trim().parse::<u128>().ok())
+            .map(U256::from)
+            .unwrap_or_else(|| U256::from(DEFAULT_MIN_ETH_WEI))
+    }
+
+    /// Balance sweep interval read from `WALLET_BALANCE_SWEEP_SECS` (falls
+    /// back to 60s if unset or unparseable).
+    pub fn sweep_interval_from_env() -> Duration {
+        let secs = std::env::var("WALLET_BALANCE_SWEEP_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_SWEEP_SECS);
+        Duration::from_secs(secs)
+    }
+
+    /// The configured ETH floor (wei).
+    pub fn eth_floor(&self) -> U256 {
+        self.eth_floor
+    }
+
+    /// Refresh ETH + USDC balances for the given wallets. Best-effort per
+    /// wallet: a failed fetch for one address is logged and skipped, it does
+    /// not abort the rest of the sweep.
+    pub async fn refresh(&self, wallets: &[Address]) {
+        let usdc_contract = IERC20::new(self.usdc, &*self.provider);
+
+        for &address in wallets {
+            let eth = match self.provider.get_balance(address).await {
+                Ok(bal) => bal,
+                Err(e) => {
+                    tracing::warn!("Failed to refresh ETH balance for wallet {address}: {e}");
+                    continue;
+                }
+            };
+
+            let usdc = match usdc_contract.balanceOf(address).call().await {
+                Ok(bal) => bal,
+                Err(e) => {
+                    tracing::warn!("Failed to refresh USDC balance for wallet {address}: {e}");
+                    continue;
+                }
+            };
+
+            let entry = WalletBalances {
+                eth,
+                usdc,
+                fetched_at: Instant::now(),
+            };
+
+            match self.balances.write() {
+                Ok(mut map) => {
+                    map.insert(address, entry);
+                }
+                Err(e) => {
+                    tracing::error!("Wallet balance cache lock poisoned: {e}");
+                }
+            }
+        }
+    }
+
+    /// Get the cached balances for a wallet, if any have been fetched yet.
+    pub fn get(&self, address: &Address) -> Option<WalletBalances> {
+        match self.balances.read() {
+            Ok(map) => map.get(address).copied(),
+            Err(e) => {
+                tracing::error!("Wallet balance cache lock poisoned: {e}");
+                None
+            }
+        }
+    }
+
+    /// Spawn a background task that refreshes balances every `interval` and,
+    /// for each wallet, emits CloudWatch metrics (best-effort, silent
+    /// locally) and — for any wallet under the ETH floor — logs a warning so
+    /// an operator can top it up before it freezes selection entirely.
+    pub fn spawn_sweep(
+        self: Arc<Self>,
+        manager_addresses: Vec<Address>,
+        interval: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let metrics = CloudWatchMetrics::new().await;
+            loop {
+                self.refresh(&manager_addresses).await;
+
+                for &address in &manager_addresses {
+                    if let Some(bal) = self.get(&address) {
+                        if bal.eth < self.eth_floor {
+                            tracing::warn!(
+                                wallet = %address,
+                                eth_balance = %bal.eth,
+                                "pool wallet below ETH floor - fund it"
+                            );
+                        }
+                        metrics
+                            .put_wallet_balances(address, bal.eth, bal.usdc)
+                            .await;
+                    }
+                }
+
+                tokio::time::sleep(interval).await;
+            }
+        })
+    }
+}
+
+/// Best-effort CloudWatch PutMetricData for pool wallet balances.
+///
+/// Local dev has no AWS credentials, so publish failures are expected there
+/// and must never spam logs — they're logged at `debug` only. Alarms on
+/// these metrics are configured separately in the SST app, not here (see
+/// `sst.config.ts`); this only emits the raw data points.
+struct CloudWatchMetrics {
+    client: aws_sdk_cloudwatch::Client,
+    environment: String,
+}
+
+impl CloudWatchMetrics {
+    async fn new() -> Self {
+        let environment = std::env::var("ENV").unwrap_or_else(|_| "unknown".to_string());
+        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        let client = aws_sdk_cloudwatch::Client::new(&config);
+        Self {
+            client,
+            environment,
+        }
+    }
+
+    async fn put_wallet_balances(&self, address: Address, eth: U256, usdc: U256) {
+        use aws_sdk_cloudwatch::types::{Dimension, MetricDatum, StandardUnit};
+
+        let env_dim = Dimension::builder()
+            .name("Environment")
+            .value(self.environment.clone())
+            .build();
+        let wallet_dim = Dimension::builder()
+            .name("WalletAddress")
+            .value(address.to_checksum(None))
+            .build();
+
+        let eth_datum = MetricDatum::builder()
+            .metric_name("WalletEthBalance")
+            .unit(StandardUnit::None)
+            .value(wei_to_f64(eth, 1e18))
+            .dimensions(env_dim.clone())
+            .dimensions(wallet_dim.clone())
+            .build();
+
+        let usdc_datum = MetricDatum::builder()
+            .metric_name("WalletUsdcBalance")
+            .unit(StandardUnit::None)
+            .value(wei_to_f64(usdc, 1e6))
+            .dimensions(env_dim)
+            .dimensions(wallet_dim)
+            .build();
+
+        if let Err(e) = self
+            .client
+            .put_metric_data()
+            .namespace("PerpCity")
+            .metric_data(eth_datum)
+            .metric_data(usdc_datum)
+            .send()
+            .await
+        {
+            // Local dev has no AWS credentials — this is the expected path there,
+            // so debug only. See sst.config.ts follow-up for the required
+            // cloudwatch:PutMetricData task-role grant in deployed environments.
+            tracing::debug!("Failed to publish wallet balance metrics for {address}: {e}");
+        }
+    }
+}
+
+/// Scale a token-unit `U256` amount (wei, USDC micros, ...) down to a human
+/// `f64` for CloudWatch. Balances comfortably fit in `u128`; saturate rather
+/// than panic in the unlikely event they don't.
+fn wei_to_f64(value: U256, scale: f64) -> f64 {
+    let capped: u128 = u128::try_from(&value).unwrap_or(u128::MAX);
+    capped as f64 / scale
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn test_address(byte: u8) -> Address {
+        Address::from([byte; 20])
+    }
+
+    #[test]
+    fn test_wei_to_f64_eth() {
+        let one_eth = U256::from(1_000_000_000_000_000_000u128);
+        assert_eq!(wei_to_f64(one_eth, 1e18), 1.0);
+    }
+
+    #[test]
+    fn test_wei_to_f64_usdc() {
+        let hundred_usdc = U256::from(100_000_000u128);
+        assert_eq!(wei_to_f64(hundred_usdc, 1e6), 100.0);
+    }
+
+    #[test]
+    fn test_wei_to_f64_zero() {
+        assert_eq!(wei_to_f64(U256::ZERO, 1e18), 0.0);
+    }
+
+    #[test]
+    fn test_get_returns_none_before_refresh() {
+        let provider = std::sync::Arc::new(
+            alloy::providers::ProviderBuilder::new()
+                .connect_http("http://127.0.0.1:1".parse().unwrap()),
+        );
+        let usdc = Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
+        let tracker = BalanceTracker::new(provider, usdc);
+
+        assert!(tracker.get(&test_address(0x01)).is_none());
+    }
+
+    #[test]
+    fn test_default_eth_floor_when_env_unset() {
+        // SAFETY: single-threaded test, no concurrent env access in this test binary segment.
+        unsafe {
+            std::env::remove_var("WALLET_MIN_ETH_WEI");
+        }
+        let provider = std::sync::Arc::new(
+            alloy::providers::ProviderBuilder::new()
+                .connect_http("http://127.0.0.1:1".parse().unwrap()),
+        );
+        let usdc = Address::from_str("0x1234567890123456789012345678901234567890").unwrap();
+        let tracker = BalanceTracker::new(provider, usdc);
+
+        assert_eq!(tracker.eth_floor(), U256::from(DEFAULT_MIN_ETH_WEI));
+    }
+}

--- a/src/services/wallet/manager.rs
+++ b/src/services/wallet/manager.rs
@@ -3,13 +3,15 @@
 //! This module provides the WalletManager, which coordinates wallet pool
 //! operations, locking, and beacon mappings into a unified interface.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
 
+use super::balances::BalanceTracker;
 use super::lock::LockHeartbeat;
 use super::{WalletLock, WalletLockGuard, WalletPool};
 use alloy::network::EthereumWallet;
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, B256, U256};
 use alloy::providers::ProviderBuilder;
 use alloy::signers::aws::AwsSigner;
 use alloy::signers::local::PrivateKeySigner;
@@ -151,6 +153,11 @@ pub struct WalletManager {
     is_test_stub: bool,
     /// Pool signers (local key or KMS) keyed by address
     signers: HashMap<Address, PoolSigner>,
+    /// Optional cached-balance view of the pool, consulted by selection to
+    /// proactively skip a wallet under the ETH floor or order by cached USDC.
+    /// `None` in test stubs and any manager that never had one attached —
+    /// selection treats that exactly like an all-missing cache (no filtering).
+    balance_tracker: Option<Arc<BalanceTracker>>,
 }
 
 impl WalletManager {
@@ -178,7 +185,18 @@ impl WalletManager {
             config: Some(config),
             is_test_stub: false,
             signers: signers_map,
+            balance_tracker: None,
         })
+    }
+
+    /// Attach a balance tracker so selection can consult cached balances
+    /// (proactive ETH-floor skip, USDC-aware ordering).
+    ///
+    /// Call this before the manager is shared behind an `Arc` — `src/lib.rs`
+    /// does so right after constructing both, before wrapping the manager
+    /// into `AppState`.
+    pub fn set_balance_tracker(&mut self, tracker: Arc<BalanceTracker>) {
+        self.balance_tracker = Some(tracker);
     }
 
     /// Create a test stub WalletManager that panics when used
@@ -191,6 +209,7 @@ impl WalletManager {
             config: None,
             is_test_stub: true,
             signers: HashMap::new(),
+            balance_tracker: None,
         }
     }
 
@@ -231,6 +250,7 @@ impl WalletManager {
             }),
             is_test_stub: false,
             signers: signers_map,
+            balance_tracker: None,
         })
     }
 
@@ -339,33 +359,210 @@ impl WalletManager {
         Ok((heartbeat, guard))
     }
 
-    /// Acquire any available wallet from the pool
+    /// Acquire any available wallet from the pool.
     ///
-    /// First pass tries every wallet once without retrying (so one busy wallet
-    /// can't head-of-line block the rest of the pool); only if ALL wallets are
-    /// locked does it fall back to the retry loop.
+    /// Delegates to [`Self::acquire_any_wallet_excluding`] with an empty
+    /// exclusion set.
     pub async fn acquire_any_wallet(&self) -> Result<WalletHandle, String> {
+        self.acquire_any_wallet_excluding(&HashSet::new()).await
+    }
+
+    /// Acquire any available wallet from the pool, skipping addresses in
+    /// `exclude`.
+    ///
+    /// Selection order:
+    /// 1. Candidates are the pool's available wallets minus `exclude`.
+    /// 2. Ordered by least-recently-used first (a wallet never acquired
+    ///    before sorts ahead of one acquired recently) — see
+    ///    [`WalletPool::lru_order`]. This is what spreads load across the
+    ///    pool instead of hammering whichever wallet happens to sort first
+    ///    in Redis (the 2026-06-30 testnet freeze: ~90% of acquisitions kept
+    ///    landing on one drained wallet).
+    /// 3. Any candidate whose cached ETH balance is known to be under the
+    ///    floor is deprioritized (skipped, unless that would empty the
+    ///    candidate list — the cache can be stale, so a floor trip must
+    ///    never hard-block acquisition).
+    ///
+    /// Then, same as before: a non-blocking fast pass over all candidates,
+    /// falling back to a retrying slow pass only if every candidate was
+    /// locked. A successful acquisition touches the LRU entry for that
+    /// wallet so the next call prefers a different one.
+    pub async fn acquire_any_wallet_excluding(
+        &self,
+        exclude: &HashSet<Address>,
+    ) -> Result<WalletHandle, String> {
         let pool = self.require_pool();
-        let config = self.require_config();
 
         let available = pool.list_available_wallets().await?;
-
         if available.is_empty() {
             return Err("No available wallets in the pool".to_string());
         }
 
+        let candidates = Self::candidates_excluding(&available, exclude);
+        if candidates.is_empty() {
+            return Err("No available wallets in the pool after exclusions".to_string());
+        }
+
+        let ordered = self.order_by_lru(candidates).await;
+        let (filtered, skipped) = self.filter_balance_floor(ordered);
+        Self::warn_skipped(&skipped, "below the ETH floor (cached)");
+
+        self.acquire_from_candidates(&filtered).await
+    }
+
+    /// Acquire an available wallet ordered by cached USDC balance,
+    /// descending (highest first), skipping addresses in `exclude`.
+    ///
+    /// This spreads USDC drain across the pool instead of the funding routes
+    /// always hitting whichever wallet happens to sort first: prop-fund-style
+    /// USDC payouts are the drain that matters for `fund_guest_wallet` /
+    /// `fund_bonus_wallet`, so ordering by cache (not LRU) is the better
+    /// signal there. `min_usdc` is a soft, cache-based filter — candidates
+    /// known (from cache) to be under it are deprioritized the same way the
+    /// ETH floor is in [`Self::acquire_any_wallet_excluding`]; the caller
+    /// still must do a fresh on-chain check after acquisition since the
+    /// cache can be stale.
+    pub async fn acquire_wallet_for_usdc(
+        &self,
+        min_usdc: U256,
+        exclude: &HashSet<Address>,
+    ) -> Result<WalletHandle, String> {
+        let pool = self.require_pool();
+
+        let available = pool.list_available_wallets().await?;
+        if available.is_empty() {
+            return Err("No available wallets in the pool".to_string());
+        }
+
+        let candidates = Self::candidates_excluding(&available, exclude);
+        if candidates.is_empty() {
+            return Err("No available wallets in the pool after exclusions".to_string());
+        }
+
+        let ordered = self.order_by_usdc_desc(candidates);
+        let (filtered, skipped) = self.filter_usdc_floor(ordered, min_usdc);
+        Self::warn_skipped(&skipped, "below the requested USDC amount (cached)");
+
+        self.acquire_from_candidates(&filtered).await
+    }
+
+    /// Addresses of the pool's available wallets, minus `exclude`.
+    fn candidates_excluding(available: &[WalletInfo], exclude: &HashSet<Address>) -> Vec<Address> {
+        available
+            .iter()
+            .map(|w| w.address)
+            .filter(|addr| !exclude.contains(addr))
+            .collect()
+    }
+
+    /// Reorder `candidates` least-recently-used first. Falls back to the
+    /// input order (unchanged) if the LRU read fails — a Redis hiccup here
+    /// must degrade to "no preference", not block acquisition.
+    async fn order_by_lru(&self, mut candidates: Vec<Address>) -> Vec<Address> {
+        let pool = self.require_pool();
+        let lru = match pool.lru_order().await {
+            Ok(order) => order,
+            Err(e) => {
+                tracing::warn!("Failed to read wallet LRU order, falling back to pool order: {e}");
+                return candidates;
+            }
+        };
+        let rank: HashMap<Address, usize> =
+            lru.iter().enumerate().map(|(i, addr)| (*addr, i)).collect();
+        candidates.sort_by_key(|addr| rank.get(addr).copied());
+        candidates
+    }
+
+    /// Reorder `candidates` by cached USDC balance, descending. A candidate
+    /// with no cache entry yet sorts last (unknown, not necessarily empty).
+    fn order_by_usdc_desc(&self, mut candidates: Vec<Address>) -> Vec<Address> {
+        let Some(tracker) = &self.balance_tracker else {
+            return candidates;
+        };
+        candidates.sort_by_key(|addr| std::cmp::Reverse(tracker.get(addr).map(|b| b.usdc)));
+        candidates
+    }
+
+    /// Split `candidates` into (passing, skipped) by cached ETH balance vs
+    /// the tracker's floor. Missing cache entries always pass — the point is
+    /// to skip a wallet we KNOW is dry, never to block on an RPC round trip
+    /// or on an empty cache. If every candidate would be skipped, returns
+    /// them all as "passing" instead: a floor trip must never turn into a
+    /// hard failure when there's no better option.
+    fn filter_balance_floor(&self, candidates: Vec<Address>) -> (Vec<Address>, Vec<Address>) {
+        let Some(tracker) = &self.balance_tracker else {
+            return (candidates, Vec::new());
+        };
+        let floor = tracker.eth_floor();
+        let (skipped, passing): (Vec<Address>, Vec<Address>) = candidates
+            .into_iter()
+            .partition(|addr| matches!(tracker.get(addr), Some(bal) if bal.eth < floor));
+        if passing.is_empty() && !skipped.is_empty() {
+            return (skipped, Vec::new());
+        }
+        (passing, skipped)
+    }
+
+    /// Same idea as [`Self::filter_balance_floor`] but for cached USDC vs
+    /// `min_usdc`. A `min_usdc` of zero never filters anything.
+    fn filter_usdc_floor(
+        &self,
+        candidates: Vec<Address>,
+        min_usdc: U256,
+    ) -> (Vec<Address>, Vec<Address>) {
+        if min_usdc.is_zero() {
+            return (candidates, Vec::new());
+        }
+        let Some(tracker) = &self.balance_tracker else {
+            return (candidates, Vec::new());
+        };
+        let (skipped, passing): (Vec<Address>, Vec<Address>) = candidates
+            .into_iter()
+            .partition(|addr| matches!(tracker.get(addr), Some(bal) if bal.usdc < min_usdc));
+        if passing.is_empty() && !skipped.is_empty() {
+            return (skipped, Vec::new());
+        }
+        (passing, skipped)
+    }
+
+    /// One warning per acquisition call summarizing skipped candidates —
+    /// never one log line per candidate.
+    fn warn_skipped(skipped: &[Address], reason: &str) {
+        if !skipped.is_empty() {
+            tracing::warn!(
+                count = skipped.len(),
+                reason,
+                "Deprioritized pool wallet(s) during acquisition"
+            );
+        }
+    }
+
+    /// Try each candidate in order: a non-blocking fast pass first (so one
+    /// busy wallet can't head-of-line block the rest), then — only if every
+    /// candidate was locked — a retrying slow pass. Touches the LRU entry
+    /// for the wallet that succeeds.
+    async fn acquire_from_candidates(
+        &self,
+        candidates: &[Address],
+    ) -> Result<WalletHandle, String> {
+        let pool = self.require_pool();
+        let config = self.require_config();
+
         // Fast pass: one non-blocking attempt per wallet.
-        for wallet_info in &available {
-            if let Some(signer) = self.signers.get(&wallet_info.address) {
+        for address in candidates {
+            if let Some(signer) = self.signers.get(address) {
                 let lock = WalletLock::with_keys(
                     pool.connection().clone(),
-                    wallet_info.address,
+                    *address,
                     pool.instance_id().to_string(),
                     config.lock_ttl,
                     pool.keys(),
                 );
 
                 if let Ok(lock_guard) = lock.try_acquire().await {
+                    if let Err(e) = pool.touch_lru(address).await {
+                        tracing::debug!("Failed to touch wallet LRU entry for {address}: {e}");
+                    }
                     return Ok(WalletHandle::new(
                         WalletSigner(signer.clone()),
                         lock_guard,
@@ -376,11 +573,11 @@ impl WalletManager {
         }
 
         // Slow pass: everything was locked — wait with retries per wallet.
-        for wallet_info in &available {
-            if let Some(signer) = self.signers.get(&wallet_info.address) {
+        for address in candidates {
+            if let Some(signer) = self.signers.get(address) {
                 let lock = WalletLock::with_keys(
                     pool.connection().clone(),
-                    wallet_info.address,
+                    *address,
                     pool.instance_id().to_string(),
                     config.lock_ttl,
                     pool.keys(),
@@ -390,6 +587,9 @@ impl WalletManager {
                     .acquire(config.lock_retry_count, config.lock_retry_delay)
                     .await
                 {
+                    if let Err(e) = pool.touch_lru(address).await {
+                        tracing::debug!("Failed to touch wallet LRU entry for {address}: {e}");
+                    }
                     return Ok(WalletHandle::new(
                         WalletSigner(signer.clone()),
                         lock_guard,
@@ -453,5 +653,91 @@ impl WalletManager {
     /// Check if this is a test stub
     pub fn is_test_stub(&self) -> bool {
         self.is_test_stub
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::wallet::sync::WalletSyncService;
+
+    // Note: These tests require a running Redis instance
+    // Run with: cargo test --lib wallet -- --ignored
+
+    #[tokio::test]
+    #[ignore = "requires Redis"]
+    async fn test_acquire_any_wallet_excluding_skips_excluded_address() {
+        let test_prefix = format!("test-{}:", uuid::Uuid::new_v4());
+        let signer_a = PrivateKeySigner::random();
+        let signer_b = PrivateKeySigner::random();
+        let addr_a = signer_a.address();
+        let addr_b = signer_b.address();
+
+        let manager = WalletManager::test_with_mock_signers_and_prefix(
+            "redis://127.0.0.1:6379",
+            vec![signer_a, signer_b],
+            &test_prefix,
+        )
+        .await
+        .expect("Failed to create manager");
+
+        WalletSyncService::new(&[addr_a, addr_b], manager.pool())
+            .sync()
+            .await
+            .expect("Failed to sync wallets");
+
+        let mut exclude = HashSet::new();
+        exclude.insert(addr_a);
+
+        let handle = manager
+            .acquire_any_wallet_excluding(&exclude)
+            .await
+            .expect("should acquire the non-excluded wallet");
+
+        assert_eq!(handle.address(), addr_b);
+
+        drop(handle);
+        manager.pool().cleanup().await.expect("Failed to cleanup");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Redis"]
+    async fn test_acquire_any_wallet_prefers_least_recently_used() {
+        let test_prefix = format!("test-{}:", uuid::Uuid::new_v4());
+        let signer_a = PrivateKeySigner::random();
+        let signer_b = PrivateKeySigner::random();
+        let addr_a = signer_a.address();
+        let addr_b = signer_b.address();
+
+        let manager = WalletManager::test_with_mock_signers_and_prefix(
+            "redis://127.0.0.1:6379",
+            vec![signer_a, signer_b],
+            &test_prefix,
+        )
+        .await
+        .expect("Failed to create manager");
+
+        WalletSyncService::new(&[addr_a, addr_b], manager.pool())
+            .sync()
+            .await
+            .expect("Failed to sync wallets");
+
+        // Touch A so it looks "most recently used" — B (never touched) must
+        // sort ahead of it and be the one acquired.
+        manager
+            .pool()
+            .touch_lru(&addr_a)
+            .await
+            .expect("Failed to touch LRU entry");
+
+        let handle = manager
+            .acquire_any_wallet()
+            .await
+            .expect("should acquire a wallet");
+
+        assert_eq!(handle.address(), addr_b);
+
+        drop(handle);
+        manager.pool().cleanup().await.expect("Failed to cleanup");
     }
 }

--- a/src/services/wallet/mod.rs
+++ b/src/services/wallet/mod.rs
@@ -5,12 +5,14 @@
 //! - WalletLock: Distributed locking to prevent concurrent wallet use
 //! - WalletManager: Central coordinator for wallet operations
 
+pub mod balances;
 pub mod lock;
 pub mod manager;
 pub mod mock;
 pub mod pool;
 pub mod sync;
 
+pub use balances::{BalanceTracker, WalletBalances};
 pub use lock::{LockHeartbeat, WalletLock, WalletLockGuard};
 pub use manager::{PoolSigner, WalletHandle, WalletManager, WalletSigner};
 pub use mock::{MockWalletHandle, MockWalletManager};

--- a/src/services/wallet/pool.rs
+++ b/src/services/wallet/pool.rs
@@ -218,6 +218,10 @@ impl WalletPool {
         // Add wallet beacons set deletion
         pipe.del(self.keys.wallet_beacons(address));
 
+        // Drop the wallet's LRU score so a re-added address sorts as
+        // never-touched instead of resurfacing with a stale score.
+        pipe.zrem(self.keys.wallet_lru(), address.to_string());
+
         // Execute all deletions atomically
         let _: () = pipe
             .query_async(&mut conn)

--- a/src/services/wallet/pool.rs
+++ b/src/services/wallet/pool.rs
@@ -259,6 +259,41 @@ impl WalletPool {
         Ok(available.into_iter().next())
     }
 
+    /// Read the wallet LRU order: addresses sorted ascending by last-acquired
+    /// score (oldest / never-acquired first). Used to spread selection across
+    /// the pool instead of hammering whichever wallet sorts first in Redis.
+    pub async fn lru_order(&self) -> Result<Vec<Address>, String> {
+        let mut conn = self.get_conn();
+
+        let members: Vec<String> = conn
+            .zrange(self.keys.wallet_lru(), 0, -1)
+            .await
+            .map_err(|e| format!("Failed to read wallet LRU order: {e}"))?;
+
+        Ok(members
+            .iter()
+            .filter_map(|addr_str| Address::from_str(addr_str).ok())
+            .collect())
+    }
+
+    /// Record that `address` was just acquired, moving it to the back of the
+    /// LRU order (least-recently-used selection prefers it last next time).
+    pub async fn touch_lru(&self, address: &Address) -> Result<(), String> {
+        let mut conn = self.get_conn();
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("System time error: {e}"))?
+            .as_millis() as i64;
+
+        let _: () = conn
+            .zadd(self.keys.wallet_lru(), address.to_string(), now_ms)
+            .await
+            .map_err(|e| format!("Failed to touch wallet LRU entry: {e}"))?;
+
+        Ok(())
+    }
+
     /// Add a beacon to a wallet's designated beacons list
     ///
     /// Uses an atomic Redis pipeline for the key operations, then updates

--- a/tests/unit_tests/transaction_execution_tests.rs
+++ b/tests/unit_tests/transaction_execution_tests.rs
@@ -4,7 +4,9 @@
 // Transaction serialization is now handled by Redis-based distributed locks
 // in the wallet module. See `WalletLock` for details.
 
-use the_beaconator::services::transaction::execution::is_nonce_error;
+use the_beaconator::services::transaction::execution::{
+    is_insufficient_funds_error, is_nonce_error,
+};
 
 #[test]
 fn test_is_nonce_error_detection() {
@@ -19,4 +21,25 @@ fn test_is_nonce_error_detection() {
     assert!(!is_nonce_error("insufficient funds"));
     assert!(!is_nonce_error("gas limit exceeded"));
     assert!(!is_nonce_error(""));
+}
+
+#[test]
+fn test_is_insufficient_funds_error_detection() {
+    // Test various insufficient-funds error patterns
+    assert!(is_insufficient_funds_error("insufficient funds"));
+    assert!(is_insufficient_funds_error("INSUFFICIENT FUNDS")); // Case insensitive
+    assert!(is_insufficient_funds_error(
+        "Error: insufficient funds for gas * price + value"
+    ));
+    assert!(is_insufficient_funds_error(
+        "insufficient balance for transfer"
+    ));
+    assert!(is_insufficient_funds_error(
+        "gas required exceeds allowance"
+    ));
+
+    // Non insufficient-funds errors should return false
+    assert!(!is_insufficient_funds_error("nonce too low"));
+    assert!(!is_insufficient_funds_error("gas limit exceeded"));
+    assert!(!is_insufficient_funds_error(""));
 }


### PR DESCRIPTION
## Motivation
On 2026-06-30 a single drained gas-payer wallet froze the entire testnet beacon fleet: selection was first-available by lock status only (skewing ~90% of traffic to one wallet), balance was never consulted, and a send failure never retried with a sibling wallet. This PR fixes all three layers plus USDC distribution for the funding routes.

## What
1. **Retry on insufficient funds** - new `is_insufficient_funds_error` classifier in `services/transaction/execution.rs` (beside `is_nonce_error`, same style + tests). The ECDSA update path now runs a bounded acquire-simulate-send loop (max attempts = pool size): a wallet that fails preflight or send with insufficient funds is excluded and a different one is acquired via the new `acquire_any_wallet_excluding`. The per-beacon update lock is held across retries.
2. **Balance floor + visibility** - new `services/wallet/balances.rs` BalanceTracker: a background sweep (default 60s, `WALLET_BALANCE_SWEEP_SECS`) caches per-wallet ETH/USDC balances, WARNs with the address when a wallet drops below the ETH floor (`WALLET_MIN_ETH_WEI`, default 0.0005 ETH), and emits best-effort CloudWatch metrics `PerpCity/WalletEthBalance` + `PerpCity/WalletUsdcBalance` (dimensions: Environment, WalletAddress; silent at debug level when AWS creds are absent locally). Acquisition skips candidates whose cached ETH is below the floor - never blocking on RPC in the hot path.
3. **LRU rotation** - a Redis ZSET (`wallet_lru`) scores wallets by last-acquired time; selection orders candidates least-recently-used first (never-used first of all) and touches the score on acquisition. Gas drain spreads across the pool instead of concentrating on one wallet.
4. **USDC load balancing** - funding routes (`fund_guest_wallet`, `fund_bonus_wallet`) now use `acquire_wallet_for_usdc`, which orders candidates by cached USDC balance DESCENDING (drains the richest wallet first, self-balancing over time), then verify the acquired wallet with FRESH on-chain balance reads inside a bounded exclusion loop - a stale cache can never mis-send; when every wallet is short, the existing user-facing insufficient-balance responses are returned unchanged.

## Operational notes
- SST follow-up (same PR as the KMS env wiring): grant the Beaconator task role `cloudwatch:PutMetricData`, and optionally add a `WalletEthBalance` low-balance alarm to replace eyeballing.
- New optional env vars documented in env.example: `WALLET_MIN_ETH_WEI`, `WALLET_BALANCE_SWEEP_SECS`.
- New Redis-gated tests for exclusion and LRU ordering (run under `make test-redis`), classifier tests run in the normal suite.

## Verification
- `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check` - clean.
- `make test` - full suite green (integration 20/20, unit suite passing, 0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cached wallet balance tracking with periodic refreshes and optional background sweeps.
  * Introduced wallet selection ordering based on recent use and available balances.
  * Added best-effort metric publishing for pool wallet balance metrics and low-balance warnings.

* **Bug Fixes**
  * Improved wallet funding and beacon update flows to retry with alternate wallets when balances are insufficient.
  * Reduced failures by treating balance checks and metric publishing as non-blocking where possible.

* **Tests**
  * Added coverage for insufficient-funds error detection and balance-tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->