### PR TITLE
Bump amazon-ecr-login pin to the commit behind v2 (v2.1.6)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Log in to ECR
         id: ecr
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 


### PR DESCRIPTION
The pin was the v2.1.5 release commit — legitimate, but the "# v2" comment no longer matched where the tag points. Pin the current v2 commit and label it with its exact version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release image workflow to use a newer version of the ECR login action.
  * No changes to the app’s user-facing behavior or release flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->