### PR TITLE
feat: touch() perps on every confirmed ECDSA beacon update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
         run: |
           ./scripts/anvil-cleanup.sh
           cargo test integration_tests -- --nocapture
+          # Anvil-only (no Redis) touch-via-multicall test; ignored by default so
+          # it does not run in the plain unit path.
+          cargo test touch_integration_tests -- --ignored --nocapture
           ./scripts/anvil-cleanup.sh
 
   # Wallet/Redis tests - parallel, needs Redis service

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,9 @@ fn audit_environment() {
         "WALLET_PRIVATE_KEYS",
         "WALLET_KMS_KEY_IDS",
         "WALLET_KMS_ALIAS_PREFIX",
+        // perpcity-bot-api key for the touch-on-update beacon->perps lookup
+        // (src/services/touch). Only needed when TOUCH_ON_UPDATE_ENABLED.
+        "BOT_API_KEY",
     ];
     // Other env vars the-beaconator reads. We don't log their values either; we only
     // check presence (for required) and whitespace cleanliness.
@@ -173,6 +176,15 @@ fn audit_environment() {
         // selection, and how often the sweep refreshes cached balances.
         "WALLET_MIN_ETH_WEI",
         "WALLET_BALANCE_SWEEP_SECS",
+        // Touch-on-update side-loop (src/services/touch). All optional; the
+        // feature is off unless TOUCH_ON_UPDATE_ENABLED is truthy, and BOT_API_URL
+        // + BOT_API_KEY + MULTICALL3_ADDRESS are then required (checked at spawn).
+        "TOUCH_ON_UPDATE_ENABLED",
+        "BOT_API_URL",
+        "TOUCH_FLUSH_INTERVAL_MS",
+        "TOUCH_MAX_BATCH",
+        "TOUCH_MAPPING_TTL_SECONDS",
+        "TOUCH_MAPPING_EMPTY_TTL_SECONDS",
     ];
 
     let mut problems = 0usize;
@@ -851,6 +863,19 @@ pub async fn create_rocket() -> Rocket<Build> {
         })
     });
 
+    // Share the wallet manager (behind an Arc) between AppState and the touch
+    // worker. Wrapped here, after set_balance_tracker/sync, which need &mut/owned.
+    let wallet_manager = std::sync::Arc::new(wallet_manager);
+
+    // Best-effort funding refresh: touch() every perp backed by a beacon after a
+    // confirmed ECDSA update. Feature-flagged (TOUCH_ON_UPDATE_ENABLED, default
+    // off); a no-op dispatcher when disabled or misconfigured.
+    let touch = services::touch::spawn_from_env(
+        std::sync::Arc::clone(&wallet_manager),
+        rpc_url.clone(),
+        multicall3_address,
+    );
+
     let app_state = AppState {
         provider: ProviderConfig {
             read_provider,
@@ -858,7 +883,7 @@ pub async fn create_rocket() -> Rocket<Build> {
             chain_id,
         },
         wallets: WalletConfig {
-            manager: std::sync::Arc::new(wallet_manager),
+            manager: wallet_manager,
             signer_address,
             signer,
             usdc_transfer_limit,
@@ -890,6 +915,7 @@ pub async fn create_rocket() -> Rocket<Build> {
             component_factories: std::sync::Arc::new(component_factory_registry),
             recipes: std::sync::Arc::new(recipe_registry),
         },
+        touch,
     };
 
     // Configure OpenAPI settings

--- a/src/models/app_state.rs
+++ b/src/models/app_state.rs
@@ -10,6 +10,7 @@ use crate::ReadOnlyProvider;
 use crate::services::beacon::BeaconTypeRegistry;
 use crate::services::beacon::ComponentFactoryRegistry;
 use crate::services::beacon::RecipeRegistry;
+use crate::services::touch::TouchDispatcher;
 use crate::services::wallet::WalletManager;
 
 /// API endpoint information for documentation
@@ -187,6 +188,9 @@ pub struct AppState {
     pub contracts: ContractAddresses,
     pub auth: AuthConfig,
     pub registries: Registries,
+    /// Dispatches beacon addresses to the background touch worker after a
+    /// confirmed ECDSA update (no-op when the feature is disabled).
+    pub touch: TouchDispatcher,
 }
 
 #[derive(Clone)]

--- a/src/routes/beacon.rs
+++ b/src/routes/beacon.rs
@@ -386,6 +386,13 @@ pub async fn update_beacon_with_ecdsa_adapter(
                      it may still confirm on-chain. Transaction hash: {tx_hash:?}"
                 )
             };
+            // Best-effort funding refresh: enqueue this beacon so the touch
+            // worker touches the perps it backs. Non-blocking and never affects
+            // this response. Only on a confirmed update, so the new index is
+            // guaranteed on-chain before we touch.
+            if outcome.confirmed {
+                state.touch.dispatch(outcome.beacon_address);
+            }
             Ok(Json(EcdsaUpdateResponse {
                 success: true,
                 data: Some(format!("Transaction hash: {tx_hash:?}")),

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -183,6 +183,10 @@ mod root_sol_interfaces {
         function openMaker(OpenMakerParams calldata params) external returns (uint256 posId);
         function openTaker(OpenTakerParams calldata params) external returns (uint256 posId);
 
+        // Permissionless funding/EMA accrual (selector 0xa55526db). Called after a
+        // beacon update to refresh funding for every perp backed by that beacon.
+        function touch() external;
+
         event MakerOpened(uint256 posId);
         event TakerOpened(uint256 posId, SwapResult sr);
 

--- a/src/services/beacon/ecdsa.rs
+++ b/src/services/beacon/ecdsa.rs
@@ -77,6 +77,9 @@ fn hold_beacon_lock_until_receipt(
 pub struct EcdsaUpdateOutcome {
     pub tx_hash: B256,
     pub confirmed: bool,
+    /// The beacon that was updated. The route uses it to dispatch a follow-up
+    /// touch of the perps backed by this beacon (only when `confirmed`).
+    pub beacon_address: Address,
 }
 
 /// Updates a beacon using ECDSA signature from the PRIVATE_KEY wallet.
@@ -401,6 +404,7 @@ pub async fn update_beacon_with_ecdsa(
             return Ok(EcdsaUpdateOutcome {
                 tx_hash,
                 confirmed: false,
+                beacon_address,
             });
         }
         Err(_) => {
@@ -420,6 +424,7 @@ pub async fn update_beacon_with_ecdsa(
             return Ok(EcdsaUpdateOutcome {
                 tx_hash,
                 confirmed: false,
+                beacon_address,
             });
         }
     };
@@ -449,6 +454,7 @@ pub async fn update_beacon_with_ecdsa(
         Ok(EcdsaUpdateOutcome {
             tx_hash,
             confirmed: true,
+            beacon_address,
         })
     } else {
         // Transaction succeeded but event not found - still consider it a success
@@ -461,6 +467,7 @@ pub async fn update_beacon_with_ecdsa(
         Ok(EcdsaUpdateOutcome {
             tx_hash,
             confirmed: true,
+            beacon_address,
         })
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,5 +2,6 @@ pub mod beacon;
 pub mod perp;
 pub mod rpc;
 pub mod safe;
+pub mod touch;
 pub mod transaction;
 pub mod wallet;

--- a/src/services/touch/mod.rs
+++ b/src/services/touch/mod.rs
@@ -1,0 +1,200 @@
+//! Best-effort funding refresh: after an ECDSA beacon update lands on-chain,
+//! `touch()` the perp(s) backing that beacon so funding and EMAs refresh with
+//! the new index.
+//!
+//! Flow: the update handler drops the beacon address into a bounded channel via
+//! [`TouchDispatcher::dispatch`] (non-blocking; never affects the update
+//! response). A single background [`TouchWorker`] resolves each beacon to its
+//! perps (via perpcity-bot-api, cached), coalesces + de-duplicates the perps
+//! across all beacons in a short flush window, and sends them as batched
+//! `Multicall3.aggregate3(allowFailure)` `touch()` transactions.
+//!
+//! The whole feature is gated behind `TOUCH_ON_UPDATE_ENABLED` (default off) and
+//! degrades to a no-op if required config is missing - a touch misconfiguration
+//! must never take down beacon updates.
+
+mod resolver;
+mod worker;
+
+pub use resolver::{
+    PerpResolver, dedup_preserving_order, entry_is_fresh, markets_url,
+    parse_perp_addresses_from_json,
+};
+pub use worker::{TouchWorker, touch_calldata, touch_calls};
+
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy::primitives::Address;
+use tokio::sync::mpsc;
+
+use crate::services::wallet::WalletManager;
+
+/// Bounded queue depth of pending beacon signals. A full channel means the
+/// worker is behind; further signals are dropped (best-effort) rather than
+/// growing memory without bound.
+const CHANNEL_CAPACITY: usize = 8192;
+
+const DEFAULT_FLUSH_INTERVAL_MS: u64 = 1000;
+const DEFAULT_MAX_BATCH: usize = 50;
+const DEFAULT_MAPPING_TTL_SECS: u64 = 300;
+const DEFAULT_MAPPING_EMPTY_TTL_SECS: u64 = 60;
+
+/// Handle the update path uses to enqueue a beacon whose perps should be
+/// touched. Cheap to clone; [`TouchDispatcher::disabled`] is a no-op used when
+/// the feature is off and in tests.
+#[derive(Clone)]
+pub struct TouchDispatcher {
+    tx: Option<mpsc::Sender<Address>>,
+}
+
+impl TouchDispatcher {
+    /// A no-op dispatcher (feature disabled).
+    pub fn disabled() -> Self {
+        Self { tx: None }
+    }
+
+    fn enabled(tx: mpsc::Sender<Address>) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    /// Non-blocking: enqueue `beacon` for a follow-up touch of its perps. Never
+    /// blocks the caller and never fails the update path.
+    pub fn dispatch(&self, beacon: Address) {
+        let Some(tx) = &self.tx else {
+            return;
+        };
+        match tx.try_send(beacon) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    target: "touch",
+                    metric = "TouchDropped",
+                    %beacon,
+                    "touch queue full; dropping beacon signal (worker behind)"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::error!(
+                    target: "touch",
+                    metric = "TouchWorkerClosed",
+                    %beacon,
+                    "touch worker channel closed; touch is disabled for this process"
+                );
+            }
+        }
+    }
+}
+
+/// Build the dispatcher and, when enabled and fully configured, spawn the touch
+/// worker. Returns a disabled (no-op) dispatcher when the flag is off, or when
+/// it is on but required config is missing/invalid - beacon updates must keep
+/// working even if the touch side-loop is misconfigured, so it degrades to
+/// "off" with a loud error rather than panicking.
+///
+/// Must be called from within the tokio runtime (it may `tokio::spawn`).
+pub fn spawn_from_env(
+    manager: Arc<WalletManager>,
+    rpc_url: String,
+    multicall3: Option<Address>,
+) -> TouchDispatcher {
+    if !env_bool("TOUCH_ON_UPDATE_ENABLED", false) {
+        tracing::info!(target: "touch", "TOUCH_ON_UPDATE_ENABLED is off; not touching perps on update");
+        return TouchDispatcher::disabled();
+    }
+
+    let Some(bot_api_url) = env_nonempty("BOT_API_URL") else {
+        tracing::error!(
+            target: "touch",
+            "TOUCH_ON_UPDATE_ENABLED is on but BOT_API_URL is not set; touch disabled"
+        );
+        return TouchDispatcher::disabled();
+    };
+    let Some(bot_api_key) = env_nonempty("BOT_API_KEY") else {
+        tracing::error!(
+            target: "touch",
+            "TOUCH_ON_UPDATE_ENABLED is on but BOT_API_KEY is not set; touch disabled"
+        );
+        return TouchDispatcher::disabled();
+    };
+    let Some(multicall3) = multicall3 else {
+        tracing::error!(
+            target: "touch",
+            "TOUCH_ON_UPDATE_ENABLED is on but MULTICALL3_ADDRESS is not set; touch disabled"
+        );
+        return TouchDispatcher::disabled();
+    };
+
+    let flush_interval = Duration::from_millis(env_parse(
+        "TOUCH_FLUSH_INTERVAL_MS",
+        DEFAULT_FLUSH_INTERVAL_MS,
+    ));
+    let max_batch = env_parse("TOUCH_MAX_BATCH", DEFAULT_MAX_BATCH).max(1);
+    let mapping_ttl = Duration::from_secs(env_parse(
+        "TOUCH_MAPPING_TTL_SECONDS",
+        DEFAULT_MAPPING_TTL_SECS,
+    ));
+    let mapping_empty_ttl = Duration::from_secs(env_parse(
+        "TOUCH_MAPPING_EMPTY_TTL_SECONDS",
+        DEFAULT_MAPPING_EMPTY_TTL_SECS,
+    ));
+
+    let resolver = match PerpResolver::new(bot_api_url, bot_api_key, mapping_ttl, mapping_empty_ttl)
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(target: "touch", error = %e, "failed to build perp resolver; touch disabled");
+            return TouchDispatcher::disabled();
+        }
+    };
+
+    let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let worker = TouchWorker::new(
+        rx,
+        resolver,
+        manager,
+        rpc_url,
+        multicall3,
+        flush_interval,
+        max_batch,
+    );
+    tokio::spawn(worker.run());
+
+    tracing::info!(
+        target: "touch",
+        flush_interval_ms = flush_interval.as_millis() as u64,
+        max_batch,
+        mapping_ttl_secs = mapping_ttl.as_secs(),
+        "touch-on-update enabled: worker started"
+    );
+    TouchDispatcher::enabled(tx)
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    match env::var(key) {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => default,
+    }
+}
+
+fn env_nonempty(key: &str) -> Option<String> {
+    env::var(key).ok().and_then(|v| {
+        let t = v.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    })
+}
+
+fn env_parse<T: std::str::FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<T>().ok())
+        .unwrap_or(default)
+}

--- a/src/services/touch/mod.rs
+++ b/src/services/touch/mod.rs
@@ -126,10 +126,12 @@ pub fn spawn_from_env(
         return TouchDispatcher::disabled();
     };
 
-    let flush_interval = Duration::from_millis(env_parse(
-        "TOUCH_FLUSH_INTERVAL_MS",
-        DEFAULT_FLUSH_INTERVAL_MS,
-    ));
+    // Floor to 1ms: tokio::time::interval panics on a zero period, which would
+    // kill the worker (while leaving the dispatcher enabled until the channel
+    // backs up). A 0 here can only come from an operator setting the env to 0.
+    let flush_interval = Duration::from_millis(
+        env_parse("TOUCH_FLUSH_INTERVAL_MS", DEFAULT_FLUSH_INTERVAL_MS).max(1),
+    );
     let max_batch = env_parse("TOUCH_MAX_BATCH", DEFAULT_MAX_BATCH).max(1);
     let mapping_ttl = Duration::from_secs(env_parse(
         "TOUCH_MAPPING_TTL_SECONDS",

--- a/src/services/touch/resolver.rs
+++ b/src/services/touch/resolver.rs
@@ -1,0 +1,237 @@
+//! Resolve which Perp market(s) are backed by a given beacon, by querying
+//! perpcity-bot-api and caching the (near-static) mapping.
+//!
+//! The bot-api serves the mapping from the indexed Goldsky Mirror:
+//! `GET /markets?beacon=<hex>&limit=500` returns a page of markets, each with a
+//! `perp_address`. One beacon can back several perps, so the result is a list.
+//!
+//! [`PerpResolver::resolve_perps`] never errors: on any failure it degrades to a
+//! fresh-enough cached entry (stale-if-error) or an empty set, so a bot-api
+//! outage never propagates into the touch worker.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+use alloy::primitives::Address;
+use serde::Deserialize;
+use tokio::sync::RwLock;
+
+/// bot-api caps `limit` at 500; request the max to minimise round trips.
+const PAGE_LIMIT: usize = 500;
+/// Hard cap on pages fetched per beacon, guarding against a buggy `has_more`
+/// that never turns false (would otherwise loop forever).
+const MAX_PAGES: usize = 40;
+/// Per-request timeout so a slow bot-api cannot stall the single touch worker.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One page of `GET /markets`. Only the fields the resolver needs are decoded;
+/// everything else is ignored, and both fields default so a partial/renamed
+/// payload degrades to "no perps" rather than a hard decode error.
+#[derive(Debug, Deserialize)]
+struct MarketsPage {
+    #[serde(default)]
+    items: Vec<MarketItem>,
+    #[serde(default)]
+    has_more: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketItem {
+    #[serde(default)]
+    perp_address: String,
+}
+
+struct CacheEntry {
+    perps: Vec<Address>,
+    fetched_at: Instant,
+}
+
+/// Cached beacon -> perps resolver backed by perpcity-bot-api.
+pub struct PerpResolver {
+    client: reqwest::Client,
+    /// bot-api base, trailing slash trimmed (we request `/markets`, never
+    /// `/markets/`, to avoid FastAPI's 307 redirect).
+    base_url: String,
+    api_key: String,
+    ttl: Duration,
+    empty_ttl: Duration,
+    cache: RwLock<HashMap<Address, CacheEntry>>,
+}
+
+impl PerpResolver {
+    pub fn new(
+        base_url: String,
+        api_key: String,
+        ttl: Duration,
+        empty_ttl: Duration,
+    ) -> Result<Self, String> {
+        let client = reqwest::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .map_err(|e| format!("failed to build touch http client: {e}"))?;
+        Ok(Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+            ttl,
+            empty_ttl,
+            cache: RwLock::new(HashMap::new()),
+        })
+    }
+
+    /// Resolve the perps backing `beacon`. Never errors: a fresh cache hit is
+    /// returned directly; otherwise it fetches and, on failure, degrades to a
+    /// stale cache entry (if any) or an empty set.
+    pub async fn resolve_perps(&self, beacon: Address) -> Vec<Address> {
+        if let Some(perps) = self.fresh_cached(beacon).await {
+            return perps;
+        }
+        match self.fetch(beacon).await {
+            Ok(perps) => {
+                self.store(beacon, perps.clone()).await;
+                perps
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "touch",
+                    metric = "MappingFetchError",
+                    %beacon,
+                    error = %e,
+                    "beacon->perps fetch failed; using stale mapping if present"
+                );
+                self.stale(beacon).await
+            }
+        }
+    }
+
+    async fn fresh_cached(&self, beacon: Address) -> Option<Vec<Address>> {
+        let cache = self.cache.read().await;
+        let entry = cache.get(&beacon)?;
+        entry_is_fresh(
+            entry.fetched_at,
+            entry.perps.is_empty(),
+            self.ttl,
+            self.empty_ttl,
+            Instant::now(),
+        )
+        .then(|| entry.perps.clone())
+    }
+
+    async fn stale(&self, beacon: Address) -> Vec<Address> {
+        self.cache
+            .read()
+            .await
+            .get(&beacon)
+            .map(|e| e.perps.clone())
+            .unwrap_or_default()
+    }
+
+    async fn store(&self, beacon: Address, perps: Vec<Address>) {
+        self.cache.write().await.insert(
+            beacon,
+            CacheEntry {
+                perps,
+                fetched_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Fetch every page for `beacon`, de-duplicating perps across pages. Returns
+    /// `Err` (leaving the cache untouched) if any page request/decode fails, so
+    /// a partial mapping is never cached as complete.
+    async fn fetch(&self, beacon: Address) -> Result<Vec<Address>, String> {
+        let mut out: Vec<Address> = Vec::new();
+        let mut offset = 0usize;
+        for _ in 0..MAX_PAGES {
+            let url = markets_url(&self.base_url, beacon, PAGE_LIMIT, offset);
+            let resp = self
+                .client
+                .get(&url)
+                .header("X-API-Key", &self.api_key)
+                .send()
+                .await
+                .map_err(|e| format!("request failed: {e}"))?;
+
+            let status = resp.status();
+            if !status.is_success() {
+                // Distinguish auth (config) errors from transient ones for alerting.
+                let metric = if status.as_u16() == 401 || status.as_u16() == 403 {
+                    "MappingAuthError"
+                } else {
+                    "MappingFetchError"
+                };
+                return Err(format!("bot-api returned {status} [{metric}]"));
+            }
+
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| format!("read body failed: {e}"))?;
+            let (perps, has_more) = parse_markets_page(&body)?;
+            out.extend(perps);
+            if !has_more {
+                break;
+            }
+            offset += PAGE_LIMIT;
+        }
+        dedup_preserving_order(&mut out);
+        Ok(out)
+    }
+}
+
+// ---- pure helpers (unit-tested from tests/unit_tests/touch_tests.rs) ----
+
+/// Build the `GET /markets` URL. No trailing slash on `/markets`: FastAPI
+/// 307-redirects `/markets/` and some HTTP clients choke on the redirect.
+pub fn markets_url(base: &str, beacon: Address, limit: usize, offset: usize) -> String {
+    format!("{base}/markets?beacon={beacon:#x}&limit={limit}&offset={offset}")
+}
+
+/// Parse the perp addresses from one `/markets` page body. Unparseable
+/// `perp_address` values are skipped (logged), not fatal.
+pub fn parse_perp_addresses_from_json(body: &str) -> Result<Vec<Address>, String> {
+    Ok(parse_markets_page(body)?.0)
+}
+
+fn parse_markets_page(body: &str) -> Result<(Vec<Address>, bool), String> {
+    let page: MarketsPage =
+        serde_json::from_str(body).map_err(|e| format!("decode failed: {e}"))?;
+    let perps = page
+        .items
+        .iter()
+        .filter_map(|it| match Address::from_str(it.perp_address.trim()) {
+            Ok(addr) => Some(addr),
+            Err(e) => {
+                tracing::warn!(
+                    target: "touch",
+                    perp_address = %it.perp_address,
+                    error = %e,
+                    "skipping unparseable perp_address from bot-api"
+                );
+                None
+            }
+        })
+        .collect();
+    Ok((perps, page.has_more))
+}
+
+/// A cache entry is fresh within `ttl` normally, or within the shorter
+/// `empty_ttl` when it resolved to no perps (so a newly-created market is
+/// picked up quickly without hammering bot-api).
+pub fn entry_is_fresh(
+    fetched_at: Instant,
+    is_empty: bool,
+    ttl: Duration,
+    empty_ttl: Duration,
+    now: Instant,
+) -> bool {
+    let age = now.saturating_duration_since(fetched_at);
+    if is_empty { age < empty_ttl } else { age < ttl }
+}
+
+/// Remove duplicate addresses while preserving first-seen order.
+pub fn dedup_preserving_order(addrs: &mut Vec<Address>) {
+    let mut seen = std::collections::HashSet::new();
+    addrs.retain(|a| seen.insert(*a));
+}

--- a/src/services/touch/worker.rs
+++ b/src/services/touch/worker.rs
@@ -1,0 +1,243 @@
+//! Coalescing touch worker.
+//!
+//! A single long-lived task receives beacon addresses (one per confirmed ECDSA
+//! update), resolves each to its perp(s), and accumulates a de-duplicated set of
+//! perps. On a flush interval (or when the set reaches `max_batch`) it sends the
+//! perps as batched `Multicall3.aggregate3(allowFailure = true)` `touch()`
+//! transactions from a pool wallet.
+//!
+//! `touch()` is time-integrated (it accrues funding over `dt` since `lastTouch`
+//! and reads the current `index()` live), so touching a perp once per flush
+//! window captures the same funding total as touching once per update, at a
+//! fraction of the tx count. Everything here is best-effort: a failure is logged
+//! and the perps are re-driven by subsequent updates.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy::primitives::{Address, Bytes};
+use alloy::sol_types::SolCall;
+use tokio::sync::mpsc;
+use tokio::time::{MissedTickBehavior, interval, timeout};
+
+use crate::routes::{IMulticall3, IPerp};
+use crate::services::wallet::WalletManager;
+
+use super::resolver::PerpResolver;
+
+/// Bounded wait for a touch batch receipt, purely to record per-perp
+/// success/failure metrics. The transaction lands regardless; this only bounds
+/// how long the (single) worker blocks per flush.
+const RECEIPT_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub struct TouchWorker {
+    rx: mpsc::Receiver<Address>,
+    resolver: PerpResolver,
+    manager: Arc<WalletManager>,
+    rpc_url: String,
+    multicall3: Address,
+    flush_interval: Duration,
+    max_batch: usize,
+}
+
+impl TouchWorker {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        rx: mpsc::Receiver<Address>,
+        resolver: PerpResolver,
+        manager: Arc<WalletManager>,
+        rpc_url: String,
+        multicall3: Address,
+        flush_interval: Duration,
+        max_batch: usize,
+    ) -> Self {
+        Self {
+            rx,
+            resolver,
+            manager,
+            rpc_url,
+            multicall3,
+            flush_interval,
+            max_batch: max_batch.max(1),
+        }
+    }
+
+    /// Run until the channel closes (all senders dropped), which only happens at
+    /// shutdown. No per-iteration error escapes the loop.
+    pub async fn run(mut self) {
+        let mut pending: HashSet<Address> = HashSet::new();
+        let mut tick = interval(self.flush_interval);
+        tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // interval's first tick is immediate; consume it so the first real flush
+        // waits a full window.
+        tick.tick().await;
+
+        loop {
+            tokio::select! {
+                maybe = self.rx.recv() => match maybe {
+                    Some(beacon) => {
+                        for perp in self.resolver.resolve_perps(beacon).await {
+                            pending.insert(perp);
+                        }
+                        if pending.len() >= self.max_batch {
+                            self.flush(&mut pending).await;
+                        }
+                    }
+                    None => {
+                        if !pending.is_empty() {
+                            self.flush(&mut pending).await;
+                        }
+                        tracing::info!(target: "touch", "touch worker channel closed; exiting");
+                        return;
+                    }
+                },
+                _ = tick.tick() => {
+                    if !pending.is_empty() {
+                        self.flush(&mut pending).await;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Send all currently-pending perps as batched touch() transactions from a
+    /// single pool wallet. Drains `pending` up front; on any acquisition/build
+    /// failure the batch is dropped (best-effort) and subsequent updates
+    /// re-enqueue the perps.
+    async fn flush(&self, pending: &mut HashSet<Address>) {
+        let perps: Vec<Address> = pending.drain().collect();
+        if perps.is_empty() {
+            return;
+        }
+
+        let handle = match self.manager.acquire_any_wallet().await {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(
+                    target: "touch",
+                    metric = "TouchWalletUnavailable",
+                    perps = perps.len(),
+                    error = %e,
+                    "no pool wallet available for touch batch; dropping (updates will re-drive)"
+                );
+                return;
+            }
+        };
+
+        let provider = match handle.build_provider(&self.rpc_url) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    target: "touch",
+                    error = %e,
+                    "failed to build provider for touch batch; dropping"
+                );
+                return;
+            }
+        };
+
+        let multicall = IMulticall3::new(self.multicall3, &provider);
+
+        for chunk in perps.chunks(self.max_batch) {
+            // A lost distributed lock means another instance may be using this
+            // wallet; sending now would risk a nonce collision.
+            if let Err(e) = handle.ensure_lock_held() {
+                tracing::warn!(
+                    target: "touch",
+                    error = %e,
+                    "lost wallet lock before touch batch; aborting flush"
+                );
+                return;
+            }
+
+            let calls = touch_calls(chunk);
+            match multicall.aggregate3(calls).send().await {
+                Ok(pending_tx) => {
+                    let tx_hash = *pending_tx.tx_hash();
+                    tracing::info!(
+                        target: "touch",
+                        metric = "TouchBatchSent",
+                        perps = chunk.len(),
+                        tx = ?tx_hash,
+                        "sent touch batch"
+                    );
+                    match timeout(RECEIPT_TIMEOUT, pending_tx.get_receipt()).await {
+                        Ok(Ok(receipt)) if receipt.status() => {
+                            // With allowFailure=true a sub-call can revert
+                            // silently; a successful touch() emits events, so a
+                            // log from the perp's address is our success signal
+                            // (same technique as batch.rs IndexUpdated checks).
+                            for perp in chunk {
+                                let touched =
+                                    receipt.inner.logs().iter().any(|l| l.address() == *perp);
+                                if touched {
+                                    tracing::debug!(
+                                        target: "touch",
+                                        metric = "TouchPerpSuccess",
+                                        %perp,
+                                        "perp touched"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        target: "touch",
+                                        metric = "TouchPerpFailure",
+                                        %perp,
+                                        tx = ?tx_hash,
+                                        "touch produced no logs (sub-call may have reverted)"
+                                    );
+                                }
+                            }
+                        }
+                        Ok(Ok(receipt)) => tracing::warn!(
+                            target: "touch",
+                            metric = "TouchBatchFailure",
+                            tx = ?receipt.transaction_hash,
+                            "touch batch transaction reverted"
+                        ),
+                        Ok(Err(e)) => tracing::warn!(
+                            target: "touch",
+                            metric = "TouchBatchFailure",
+                            tx = ?tx_hash,
+                            error = %e,
+                            "failed to get touch batch receipt (may still confirm)"
+                        ),
+                        Err(_) => tracing::warn!(
+                            target: "touch",
+                            metric = "TouchBatchFailure",
+                            tx = ?tx_hash,
+                            "timed out waiting for touch batch receipt (may still confirm)"
+                        ),
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    target: "touch",
+                    metric = "TouchBatchFailure",
+                    perps = chunk.len(),
+                    error = %e,
+                    "failed to send touch batch (RpcError usually = wallet out of native gas)"
+                ),
+            }
+        }
+    }
+}
+
+// ---- pure helpers (unit-tested from tests/unit_tests/touch_tests.rs) ----
+
+/// Calldata for `Perp.touch()` (selector 0xa55526db, no arguments).
+pub fn touch_calldata() -> Bytes {
+    Bytes::from(SolCall::abi_encode(&IPerp::touchCall {}))
+}
+
+/// One `allowFailure` multicall entry per perp, each calling `touch()`.
+pub fn touch_calls(perps: &[Address]) -> Vec<IMulticall3::Call3> {
+    let data = touch_calldata();
+    perps
+        .iter()
+        .map(|perp| IMulticall3::Call3 {
+            target: *perp,
+            allowFailure: true,
+            callData: data.clone(),
+        })
+        .collect()
+}

--- a/tests/contracts/MockMulticall3.sol
+++ b/tests/contracts/MockMulticall3.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/// Minimal Multicall3.aggregate3 stand-in for the touch integration test.
+/// Matches the real Multicall3 semantics for the subset the-beaconator uses:
+/// each Call3 is executed, and a call is only allowed to revert the batch when
+/// allowFailure is false.
+contract MockMulticall3 {
+    struct Call3 {
+        address target;
+        bool allowFailure;
+        bytes callData;
+    }
+
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    function aggregate3(Call3[] calldata calls)
+        external
+        payable
+        returns (Result[] memory returnData)
+    {
+        uint256 length = calls.length;
+        returnData = new Result[](length);
+        for (uint256 i = 0; i < length; i++) {
+            (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
+            if (!calls[i].allowFailure) {
+                require(success, "Multicall3: call failed");
+            }
+            returnData[i] = Result(success, ret);
+        }
+    }
+}

--- a/tests/contracts/MockTouchable.sol
+++ b/tests/contracts/MockTouchable.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/// Stand-in for a Perp exposing touch(): bumps a counter and emits an event, so
+/// a receipt log from this address signals a successful touch (mirrors how the
+/// worker infers per-perp success). Selector of touch() is 0xa55526db.
+contract MockTouchable {
+    uint256 public touchCount;
+
+    event Touched(uint256 count);
+
+    function touch() external {
+        touchCount++;
+        emit Touched(touchCount);
+    }
+}

--- a/tests/contracts/RevertingTouchable.sol
+++ b/tests/contracts/RevertingTouchable.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/// A touch() that always reverts, used to prove that
+/// aggregate3(allowFailure = true) isolates a bad perp without reverting the
+/// whole batch (an uninitialized-pool / bad-market perp in production).
+contract RevertingTouchable {
+    function touch() external pure {
+        revert("touch reverts");
+    }
+}

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -9,6 +9,7 @@ pub mod nonce_conflict_tests;
 // pub mod perp_deployment_integration_tests; // Temporarily disabled during PerpManager refactor
 pub mod perp_integration_tests;
 pub mod register_beacon_integration_tests;
+pub mod touch_integration_tests;
 // pub mod transaction_execution_integration_tests; // Removed - nonce management obsolete with WalletManager
 pub mod modular_registry_tests;
 pub mod wallet_test;

--- a/tests/integration_tests/touch_integration_tests.rs
+++ b/tests/integration_tests/touch_integration_tests.rs
@@ -1,0 +1,102 @@
+//! On-chain integration test for the touch-via-Multicall3 mechanic.
+//!
+//! Proves that `touch_calls` + `Multicall3.aggregate3(allowFailure = true)`:
+//!   1. executes `touch()` on a healthy perp (its counter advances), and
+//!   2. isolates a reverting perp - a bad sub-call does NOT revert the batch.
+//!
+//! This is the worker's on-chain send path (a direct mirror of batch.rs), run
+//! against a local Anvil with mock contracts. It uses a direct signer provider,
+//! not the Redis-backed wallet pool, so it needs only Anvil (no Redis).
+
+use alloy::network::{EthereumWallet, TransactionBuilder};
+use alloy::primitives::{Address, U256};
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
+use serial_test::serial;
+use the_beaconator::routes::IMulticall3;
+use the_beaconator::services::touch::touch_calls;
+
+use crate::test_utils::{AnvilManager, load_contract_bytecode};
+
+alloy::sol! {
+    #[sol(rpc)]
+    interface IMockTouchable {
+        function touchCount() external view returns (uint256);
+    }
+}
+
+async fn deploy(provider: &impl Provider, name: &str) -> Address {
+    let bytecode = load_contract_bytecode(name);
+    let tx = TransactionRequest::default().with_deploy_code(bytecode);
+    let receipt = provider
+        .send_transaction(tx)
+        .await
+        .expect("deploy send")
+        .get_receipt()
+        .await
+        .expect("deploy receipt");
+    receipt.contract_address.expect("deployed contract address")
+}
+
+#[tokio::test]
+#[serial]
+#[ignore = "requires Anvil (run in the integration CI job)"]
+async fn touch_via_multicall_touches_healthy_perp_and_isolates_reverting_one() {
+    let anvil = AnvilManager::new().await;
+    let wallet = EthereumWallet::from(anvil.deployer_signer());
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect_http(anvil.rpc_url().parse().expect("rpc url"));
+
+    // Multicall3 + a healthy perp + a perp whose touch() always reverts.
+    let multicall_addr = deploy(&provider, "MockMulticall3").await;
+    let good = deploy(&provider, "MockTouchable").await;
+    let bad = deploy(&provider, "RevertingTouchable").await;
+
+    // The worker touches every perp for a beacon in one batch. Put the reverting
+    // perp in the middle to prove the good ones on either side still execute.
+    let good2 = deploy(&provider, "MockTouchable").await;
+    let calls = touch_calls(&[good, bad, good2]);
+    assert_eq!(calls.len(), 3);
+
+    let multicall = IMulticall3::new(multicall_addr, &provider);
+
+    // Simulate: allowFailure means the batch does not revert; the middle call
+    // reports success = false, the healthy ones report success = true.
+    let results = multicall
+        .aggregate3(calls.clone())
+        .call()
+        .await
+        .expect("aggregate3 simulation must not revert with allowFailure");
+    assert!(results[0].success, "healthy perp touch should succeed");
+    assert!(
+        !results[1].success,
+        "reverting perp touch should fail (isolated)"
+    );
+    assert!(
+        results[2].success,
+        "second healthy perp touch should succeed"
+    );
+
+    // Execute for real and confirm the batch tx itself succeeded.
+    let receipt = multicall
+        .aggregate3(calls)
+        .send()
+        .await
+        .expect("aggregate3 send")
+        .get_receipt()
+        .await
+        .expect("aggregate3 receipt");
+    assert!(receipt.status(), "touch batch tx must not revert");
+
+    // Both healthy perps were actually touched on-chain; the reverting one made
+    // no state change but did not block the others.
+    for perp in [good, good2] {
+        let count = IMockTouchable::new(perp, &provider)
+            .touchCount()
+            .call()
+            .await
+            .expect("touchCount");
+        assert_eq!(count, U256::from(1), "healthy perp should be touched once");
+    }
+}

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -602,6 +602,7 @@ pub async fn create_test_app_state() -> AppState {
             component_factories: Arc::new(ComponentFactoryRegistry::test_stub()),
             recipes: Arc::new(RecipeRegistry::test_stub()),
         },
+        touch: the_beaconator::services::touch::TouchDispatcher::disabled(),
     }
 }
 
@@ -671,6 +672,7 @@ pub async fn create_isolated_test_app_state() -> (AppState, AnvilManager) {
             component_factories: Arc::new(ComponentFactoryRegistry::test_stub()),
             recipes: Arc::new(RecipeRegistry::test_stub()),
         },
+        touch: the_beaconator::services::touch::TouchDispatcher::disabled(),
     };
 
     (app_state, anvil)
@@ -765,6 +767,7 @@ pub async fn create_isolated_test_app_state_with_redis() -> (AppState, AnvilMana
             component_factories: Arc::new(ComponentFactoryRegistry::test_stub()),
             recipes: Arc::new(RecipeRegistry::test_stub()),
         },
+        touch: the_beaconator::services::touch::TouchDispatcher::disabled(),
     };
 
     (app_state, anvil)
@@ -831,6 +834,7 @@ pub async fn create_test_app_state_with_account(account_index: usize) -> AppStat
             component_factories: Arc::new(ComponentFactoryRegistry::test_stub()),
             recipes: Arc::new(RecipeRegistry::test_stub()),
         },
+        touch: the_beaconator::services::touch::TouchDispatcher::disabled(),
     }
 }
 
@@ -948,6 +952,7 @@ pub async fn create_simple_test_app_state() -> AppState {
             component_factories: Arc::new(ComponentFactoryRegistry::test_stub()),
             recipes: Arc::new(RecipeRegistry::test_stub()),
         },
+        touch: the_beaconator::services::touch::TouchDispatcher::disabled(),
     }
 }
 
@@ -1014,6 +1019,7 @@ pub async fn create_test_app_state_with_provider(
             component_factories: Arc::new(ComponentFactoryRegistry::test_stub()),
             recipes: Arc::new(RecipeRegistry::test_stub()),
         },
+        touch: the_beaconator::services::touch::TouchDispatcher::disabled(),
     }
 }
 

--- a/tests/unit_tests/mod.rs
+++ b/tests/unit_tests/mod.rs
@@ -14,6 +14,7 @@ pub mod services_transaction_events_simple_tests;
 // pub mod services_transaction_execution_comprehensive_tests; // Removed - nonce management obsolete with WalletManager
 pub mod factory_beacon_tests;
 pub mod modular_beacon_tests;
+pub mod touch_tests;
 pub mod transaction_events_tests;
 pub mod transaction_execution_tests;
 pub mod wallet_route_tests;

--- a/tests/unit_tests/touch_tests.rs
+++ b/tests/unit_tests/touch_tests.rs
@@ -1,0 +1,155 @@
+//! Unit tests for the touch-on-update pure helpers (no network / no chain).
+
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+use alloy::primitives::Address;
+use the_beaconator::services::touch::{
+    dedup_preserving_order, entry_is_fresh, markets_url, parse_perp_addresses_from_json,
+    touch_calldata, touch_calls,
+};
+
+#[test]
+fn markets_url_has_no_trailing_slash_and_expected_query() {
+    let beacon = Address::from_str("0x00000000000000000000000000000000000000ab").unwrap();
+    let url = markets_url("https://bot.example.com", beacon, 500, 0);
+    assert_eq!(
+        url,
+        "https://bot.example.com/markets?beacon=0x00000000000000000000000000000000000000ab&limit=500&offset=0"
+    );
+    // FastAPI 307-redirects /markets/ -> /markets; we must request without it.
+    assert!(url.contains("/markets?"));
+    assert!(!url.contains("/markets/"));
+}
+
+#[test]
+fn markets_url_paginates_via_offset() {
+    let beacon = Address::repeat_byte(0x11);
+    let url = markets_url("http://botapi.testnet.perpcity.sst:8001", beacon, 500, 1000);
+    assert!(url.ends_with("&limit=500&offset=1000"));
+}
+
+#[test]
+fn parse_markets_json_extracts_perp_addresses() {
+    let body = r#"{
+        "items": [
+            {"perp_address": "0x1111111111111111111111111111111111111111", "beacon_address": "0xabc"},
+            {"perp_address": "0x2222222222222222222222222222222222222222"}
+        ],
+        "total": 2, "limit": 500, "offset": 0, "has_more": false
+    }"#;
+    let perps = parse_perp_addresses_from_json(body).unwrap();
+    assert_eq!(
+        perps,
+        vec![
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap(),
+            Address::from_str("0x2222222222222222222222222222222222222222").unwrap(),
+        ]
+    );
+}
+
+#[test]
+fn parse_markets_json_empty_items_is_empty() {
+    let body = r#"{"items": [], "has_more": false}"#;
+    assert!(parse_perp_addresses_from_json(body).unwrap().is_empty());
+}
+
+#[test]
+fn parse_markets_json_skips_unparseable_addresses() {
+    let body = r#"{"items": [
+        {"perp_address": "not-an-address"},
+        {"perp_address": "0x3333333333333333333333333333333333333333"}
+    ]}"#;
+    let perps = parse_perp_addresses_from_json(body).unwrap();
+    assert_eq!(
+        perps,
+        vec![Address::from_str("0x3333333333333333333333333333333333333333").unwrap()]
+    );
+}
+
+#[test]
+fn parse_markets_json_malformed_is_error() {
+    assert!(parse_perp_addresses_from_json("not json at all").is_err());
+}
+
+#[test]
+fn entry_freshness_uses_ttl_for_nonempty() {
+    let now = Instant::now();
+    let ttl = Duration::from_secs(300);
+    let empty_ttl = Duration::from_secs(60);
+    assert!(entry_is_fresh(
+        now,
+        false,
+        ttl,
+        empty_ttl,
+        now + Duration::from_secs(100)
+    ));
+    assert!(!entry_is_fresh(
+        now,
+        false,
+        ttl,
+        empty_ttl,
+        now + Duration::from_secs(301)
+    ));
+}
+
+#[test]
+fn entry_freshness_uses_shorter_empty_ttl_for_empty() {
+    let now = Instant::now();
+    let ttl = Duration::from_secs(300);
+    let empty_ttl = Duration::from_secs(60);
+    // Within the empty TTL -> fresh.
+    assert!(entry_is_fresh(
+        now,
+        true,
+        ttl,
+        empty_ttl,
+        now + Duration::from_secs(30)
+    ));
+    // Past the empty TTL -> stale, even though it is still within the normal TTL.
+    assert!(!entry_is_fresh(
+        now,
+        true,
+        ttl,
+        empty_ttl,
+        now + Duration::from_secs(61)
+    ));
+}
+
+#[test]
+fn dedup_preserves_first_seen_order() {
+    let a = Address::repeat_byte(1);
+    let b = Address::repeat_byte(2);
+    let c = Address::repeat_byte(3);
+    let mut v = vec![a, b, a, c, b, a];
+    dedup_preserving_order(&mut v);
+    assert_eq!(v, vec![a, b, c]);
+}
+
+#[test]
+fn touch_calldata_is_the_touch_selector() {
+    // keccak256("touch()")[..4] == 0xa55526db
+    let data = touch_calldata();
+    assert_eq!(data.len(), 4);
+    assert_eq!(data.as_ref(), [0xa5, 0x55, 0x26, 0xdb]);
+}
+
+#[test]
+fn touch_calls_are_allow_failure_per_perp() {
+    let perps = vec![Address::repeat_byte(0xaa), Address::repeat_byte(0xbb)];
+    let calls = touch_calls(&perps);
+    assert_eq!(calls.len(), 2);
+    for (i, call) in calls.iter().enumerate() {
+        assert!(
+            call.allowFailure,
+            "touch sub-calls must not revert the batch"
+        );
+        assert_eq!(call.target, perps[i]);
+        assert_eq!(call.callData.as_ref(), [0xa5, 0x55, 0x26, 0xdb]);
+    }
+}
+
+#[test]
+fn touch_calls_empty_input_yields_no_calls() {
+    assert!(touch_calls(&[]).is_empty());
+}


### PR DESCRIPTION
## What

After a **confirmed** ECDSA beacon update lands on-chain, refresh funding + EMAs for the perp(s) backed by that beacon by calling `Perp.touch()`. Today nothing refreshes a perp's funding except trade activity, so a market whose beacon moves but sees no trades drifts until the next interaction.

A single background worker **coalesces** the perps from all beacon updates in a short flush window, **dedupes** them, and sends them as batched `Multicall3.aggregate3(allowFailure = true)` `touch()` transactions from a pool wallet. This is correct because `touch()` is time-integrated (accrues over `dt` since `lastTouch`, reads the current `index()` live), so touching once per window captures the same funding total as touching once per update, at a fraction of the tx count.

## How

- **`src/services/touch/`** (new): `TouchDispatcher` (non-blocking `try_send`), `PerpResolver` (bot-api `GET /markets?beacon=<hex>` -> perp addresses, cached with stale-if-error + a shorter negative TTL for empty beacons), `TouchWorker` (coalesce -> dedupe -> chunked `aggregate3`).
- `IPerp.touch()` `sol!` binding (selector `0xa55526db`).
- The `update_beacon_with_ecdsa_adapter` handler dispatches only on `confirmed` updates; the updater's response is never affected.
- Wallet pool + `build_provider` + `ensure_lock_held` reused from the existing send paths.

## Behavior / safety

- **Feature-flagged**: `TOUCH_ON_UPDATE_ENABLED` (default **off**), enabled testnet-first.
- Misconfig (feature on but `BOT_API_URL` / `BOT_API_KEY` / `MULTICALL3_ADDRESS` missing) -> disabled with a loud error, **not** a startup crash. A touch misconfig must never take down beacon updates.
- Best-effort end to end; structured `tracing` metrics on `target: "touch"` (`TouchBatchSent`, `TouchPerpSuccess/Failure`, `TouchDropped`, `TouchWalletUnavailable`, `MappingFetchError/AuthError`, ...).
- Edge cases handled explicitly: empty/unindexed beacons, bot-api 401/5xx/timeout, mid-pagination failure, per-perp reverts (isolated by `allowFailure`), wallet-pool exhaustion, channel overflow, stale mapping after `setBeacon`.

## Config (new)

`TOUCH_ON_UPDATE_ENABLED`, `BOT_API_URL` (in-VPC `http://BotApi.<stage>.perpcity.sst:8001`), `BOT_API_KEY` (Secrets Manager `the-beaconator/<env>/BOT_API_KEY`), and tunables `TOUCH_FLUSH_INTERVAL_MS` (1000), `TOUCH_MAX_BATCH` (50), `TOUCH_MAPPING_TTL_SECONDS` (300), `TOUCH_MAPPING_EMPTY_TTL_SECONDS` (60). `MULTICALL3_ADDRESS` becomes required when the feature is on.

**Companion change (separate PR):** wire `the-beaconator/<env>/BOT_API_KEY` + `BOT_API_URL` into `perpcity-client/sst.config.ts` for the Beaconator service, and mint the bot-api key.

## Testing (local)

- `cargo fmt --all -- --check` OK
- `cargo clippy --all --all-targets -- -D warnings` clean
- `cargo test unit_tests` -> 184 passed (12 new touch unit tests: URL building, JSON parsing, cache freshness, dedup, `touch()` selector, `allowFailure` call assembly)
- `cargo test touch_integration_tests -- --ignored` -> passes on Anvil (deploys a mock Multicall3 + healthy/reverting perps; proves `aggregate3(allowFailure)` touches the healthy perps and isolates the reverting one). Wired into the integration CI job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic post-update “touch” dispatch after confirmed beacon ECDSA updates, refreshing dependent perps via a background, batched multicall flow.
  * Introduced touch configuration and validation for enabling the feature via environment variables.
  * Added a permissionless `touch()` hook to the perp contract interface used by the multicall worker.
* **Bug Fixes**
  * Confirmed beacon updates now trigger best-effort refreshes for dependent markets.
* **Tests**
  * Added unit and integration tests covering touch calldata/calls generation, batching semantics, allow-failure behavior, and resolver parsing/freshness.
* **Chores**
  * CI now runs an additional Anvil-only Rust touch integration test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->