### PR TITLE
fix(touch): explicit gas limit on touch batches

### DIFF
--- a/src/services/touch/mod.rs
+++ b/src/services/touch/mod.rs
@@ -20,7 +20,9 @@ pub use resolver::{
     PerpResolver, dedup_preserving_order, entry_is_fresh, markets_url,
     parse_perp_addresses_from_json,
 };
-pub use worker::{TouchWorker, touch_batch_gas_limit, touch_calldata, touch_calls};
+pub use worker::{
+    MAX_BATCH_CEILING, TouchWorker, touch_batch_gas_limit, touch_calldata, touch_calls,
+};
 
 use std::env;
 use std::sync::Arc;
@@ -132,7 +134,9 @@ pub fn spawn_from_env(
     let flush_interval = Duration::from_millis(
         env_parse("TOUCH_FLUSH_INTERVAL_MS", DEFAULT_FLUSH_INTERVAL_MS).max(1),
     );
-    let max_batch = env_parse("TOUCH_MAX_BATCH", DEFAULT_MAX_BATCH).max(1);
+    // Ceiling keeps the batch's explicit gas limit under the block gas limit
+    // even if an operator sets TOUCH_MAX_BATCH very high.
+    let max_batch = env_parse("TOUCH_MAX_BATCH", DEFAULT_MAX_BATCH).clamp(1, MAX_BATCH_CEILING);
     let mapping_ttl = Duration::from_secs(env_parse(
         "TOUCH_MAPPING_TTL_SECONDS",
         DEFAULT_MAPPING_TTL_SECS,

--- a/src/services/touch/mod.rs
+++ b/src/services/touch/mod.rs
@@ -20,7 +20,7 @@ pub use resolver::{
     PerpResolver, dedup_preserving_order, entry_is_fresh, markets_url,
     parse_perp_addresses_from_json,
 };
-pub use worker::{TouchWorker, touch_calldata, touch_calls};
+pub use worker::{TouchWorker, touch_batch_gas_limit, touch_calldata, touch_calls};
 
 use std::env;
 use std::sync::Arc;

--- a/src/services/touch/worker.rs
+++ b/src/services/touch/worker.rs
@@ -45,6 +45,11 @@ const GAS_PER_PERP: u64 = 300_000;
 /// same transaction gas limit.
 const GAS_BASE: u64 = 200_000;
 
+/// Ceiling on perps per batch, so the explicit gas limit stays comfortably
+/// under Arbitrum's 32M block gas limit (80 * 300k + 200k = 24.2M) no matter
+/// how high an operator sets `TOUCH_MAX_BATCH`.
+pub const MAX_BATCH_CEILING: usize = 80;
+
 pub struct TouchWorker {
     rx: mpsc::Receiver<Address>,
     resolver: PerpResolver,
@@ -73,7 +78,7 @@ impl TouchWorker {
             rpc_url,
             multicall3,
             flush_interval,
-            max_batch: max_batch.max(1),
+            max_batch: max_batch.clamp(1, MAX_BATCH_CEILING),
         }
     }
 
@@ -246,8 +251,11 @@ pub fn touch_calldata() -> Bytes {
 
 /// Explicit gas limit for a touch batch of `n_perps` sub-calls. See
 /// [`GAS_PER_PERP`] for why the node's estimate must not be used here.
+/// Saturating: callers are already clamped to [`MAX_BATCH_CEILING`], so a
+/// value large enough to saturate cannot occur, but a silly input must not
+/// panic in debug builds.
 pub fn touch_batch_gas_limit(n_perps: usize) -> u64 {
-    GAS_BASE + GAS_PER_PERP * (n_perps as u64)
+    GAS_BASE.saturating_add(GAS_PER_PERP.saturating_mul(n_perps as u64))
 }
 
 /// One `allowFailure` multicall entry per perp, each calling `touch()`.

--- a/src/services/touch/worker.rs
+++ b/src/services/touch/worker.rs
@@ -31,6 +31,20 @@ use super::resolver::PerpResolver;
 /// how long the (single) worker blocks per flush.
 const RECEIPT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Gas allowance per touch() sub-call. eth_estimateGas cannot size this batch:
+/// with `allowFailure = true` the outer transaction succeeds even when every
+/// sub-call runs out of gas, so the estimator converges on a limit that covers
+/// only the multicall bookkeeping and starves the sub-calls (on prod, 100% of
+/// touches OOG'd inside the perp while the batch tx "succeeded" with no logs).
+/// A touch() costs ~130k gas today; 300k leaves room for state growth. Unused
+/// gas is refunded, so overshooting costs nothing.
+const GAS_PER_PERP: u64 = 300_000;
+
+/// Fixed allowance on top of the per-perp gas: multicall dispatch overhead
+/// plus Arbitrum's calldata (L1 poster) component, both charged against the
+/// same transaction gas limit.
+const GAS_BASE: u64 = 200_000;
+
 pub struct TouchWorker {
     rx: mpsc::Receiver<Address>,
     resolver: PerpResolver,
@@ -152,7 +166,8 @@ impl TouchWorker {
             }
 
             let calls = touch_calls(chunk);
-            match multicall.aggregate3(calls).send().await {
+            let gas_limit = touch_batch_gas_limit(chunk.len());
+            match multicall.aggregate3(calls).gas(gas_limit).send().await {
                 Ok(pending_tx) => {
                     let tx_hash = *pending_tx.tx_hash();
                     tracing::info!(
@@ -227,6 +242,12 @@ impl TouchWorker {
 /// Calldata for `Perp.touch()` (selector 0xa55526db, no arguments).
 pub fn touch_calldata() -> Bytes {
     Bytes::from(SolCall::abi_encode(&IPerp::touchCall {}))
+}
+
+/// Explicit gas limit for a touch batch of `n_perps` sub-calls. See
+/// [`GAS_PER_PERP`] for why the node's estimate must not be used here.
+pub fn touch_batch_gas_limit(n_perps: usize) -> u64 {
+    GAS_BASE + GAS_PER_PERP * (n_perps as u64)
 }
 
 /// One `allowFailure` multicall entry per perp, each calling `touch()`.

--- a/tests/unit_tests/touch_tests.rs
+++ b/tests/unit_tests/touch_tests.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use alloy::primitives::Address;
 use the_beaconator::services::touch::{
     dedup_preserving_order, entry_is_fresh, markets_url, parse_perp_addresses_from_json,
-    touch_calldata, touch_calls,
+    touch_batch_gas_limit, touch_calldata, touch_calls,
 };
 
 #[test]
@@ -152,4 +152,20 @@ fn touch_calls_are_allow_failure_per_perp() {
 #[test]
 fn touch_calls_empty_input_yields_no_calls() {
     assert!(touch_calls(&[]).is_empty());
+}
+
+#[test]
+fn touch_batch_gas_limit_scales_per_perp() {
+    // A single touch() runs ~130k gas on prod perps; the estimator cannot be
+    // trusted with allowFailure=true (it starves the sub-calls), so the limit
+    // must comfortably cover every sub-call plus batch overhead.
+    let one = touch_batch_gas_limit(1);
+    assert!(one >= 200_000, "one perp needs sub-call gas + overhead");
+    let per_perp = touch_batch_gas_limit(2) - one;
+    assert!(
+        per_perp >= 150_000,
+        "each extra perp needs its own allowance"
+    );
+    // Full default batch (50) must stay under Arbitrum's 32M block gas limit.
+    assert!(touch_batch_gas_limit(50) < 32_000_000);
 }

--- a/tests/unit_tests/touch_tests.rs
+++ b/tests/unit_tests/touch_tests.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 
 use alloy::primitives::Address;
 use the_beaconator::services::touch::{
-    dedup_preserving_order, entry_is_fresh, markets_url, parse_perp_addresses_from_json,
-    touch_batch_gas_limit, touch_calldata, touch_calls,
+    MAX_BATCH_CEILING, dedup_preserving_order, entry_is_fresh, markets_url,
+    parse_perp_addresses_from_json, touch_batch_gas_limit, touch_calldata, touch_calls,
 };
 
 #[test]
@@ -158,14 +158,16 @@ fn touch_calls_empty_input_yields_no_calls() {
 fn touch_batch_gas_limit_scales_per_perp() {
     // A single touch() runs ~130k gas on prod perps; the estimator cannot be
     // trusted with allowFailure=true (it starves the sub-calls), so the limit
-    // must comfortably cover every sub-call plus batch overhead.
-    let one = touch_batch_gas_limit(1);
-    assert!(one >= 200_000, "one perp needs sub-call gas + overhead");
-    let per_perp = touch_batch_gas_limit(2) - one;
-    assert!(
-        per_perp >= 150_000,
-        "each extra perp needs its own allowance"
-    );
-    // Full default batch (50) must stay under Arbitrum's 32M block gas limit.
-    assert!(touch_batch_gas_limit(50) < 32_000_000);
+    // must comfortably cover every sub-call plus batch overhead. Exact values
+    // pin the constants: 200k base + 300k per perp.
+    assert_eq!(touch_batch_gas_limit(1), 500_000);
+    assert_eq!(touch_batch_gas_limit(2) - touch_batch_gas_limit(1), 300_000);
+    // The largest batch the worker can send (max_batch is clamped to the
+    // ceiling) must stay under Arbitrum's 32M block gas limit.
+    assert!(touch_batch_gas_limit(MAX_BATCH_CEILING) < 32_000_000);
+}
+
+#[test]
+fn touch_batch_gas_limit_saturates_instead_of_panicking() {
+    assert_eq!(touch_batch_gas_limit(usize::MAX), u64::MAX);
 }


### PR DESCRIPTION
## Problem

Touch-on-update went live on prod (perpcity-client #573) but funding rates never moved on index pushes. Prod logs show 100% of touch sub-calls failing with "touch produced no logs", every ~15min batch, for both beacon-backed perps.

Traced tx `0xbdeac7ac33e42f2fcb87d5df87c9cf2011e8841c17629ee4dd382fd79d87531f` with `debug_traceTransaction`: the tx was sent with a ~125k gas limit; inside `Multicall3.aggregate3` the perp's delegatecall got ~75k and died `out of gas`. `allowFailure = true` swallowed the failure, so the outer tx succeeded with zero logs and no `RatesAndEmasRefreshed`.

## Root cause

`eth_estimateGas` binary-searches for the lowest gas at which the *transaction* does not revert. With `allowFailure = true` the transaction never reverts — even when every sub-call OOGs — so the estimate converges on just the multicall bookkeeping (~125k total) while a single `touch()` alone needs ~118-126k (measured on both prod perps). The sub-calls are starved by construction.

The "~25% of touch sub-calls no-op, known benign" observed on testnet in perpcity-client #573 was this same bug firing intermittently, not a benign no-op.

## Fix

Stop trusting the node's estimate for these batches: set an explicit gas limit of `200k base + 300k per perp` on the `aggregate3` call. Base covers multicall dispatch + Arbitrum's L1 poster gas (charged against the same limit); 300k/perp is ~2.3x today's measured `touch()` cost. Unused gas is refunded, and a full 50-perp batch (15.2M) stays well under Arbitrum's 32M block limit.

## Verification

- `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, unit tests pass (new test covers the gas formula).
- Simulated the exact prod batch (`aggregate3` on `0x632E...47C5`) from the touch wallet with a 500k limit: sub-call succeeds.
- Post-deploy signal: prod beaconator logs should flip from `TouchPerpFailure` to `TouchPerpSuccess` (debug) / touch txs should carry `RatesAndEmasRefreshed` logs, and funding on the beacon-backed markets should move with index pushes.

## Ship path

Merge here -> run the "Promote image to production" workflow -> land a prod redeploy in perpcity-client (image digest is baked into the task def; promote alone does nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batched touch execution by applying an explicit, per-batch gas limit instead of relying on automatic estimation.
  * Prevented operator-configured batch sizes from growing beyond a safe ceiling by clamping the maximum batch size at runtime.

* **Tests**
  * Added unit coverage for the gas-limit estimator, including scaling behavior per added item, saturation for extreme inputs, and confirmation the default ceiling stays well below expected network gas limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->