### PR TITLE
ci: cut CI/build time with a cargo-chef deps layer + unified rust-cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,14 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
+      # One shared cache key across every compile job. rust-cache only caches
+      # the registry + compiled dependencies (not our own crates), so all jobs
+      # can safely share it and each restores the same warm ~600-crate build
+      # instead of maintaining its own copy.
       - name: Cache Rust dependencies and build
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "ci-lint"
+          shared-key: "ci"
           save-if: true
       - name: Lint
         run: cargo clippy --all --all-targets -- -D warnings
@@ -53,7 +57,7 @@ jobs:
       - name: Cache Rust dependencies and build
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "ci-test"
+          shared-key: "ci"
           save-if: true
       - name: Run unit tests
         run: cargo test unit_tests -- --nocapture
@@ -68,7 +72,7 @@ jobs:
       - name: Cache Rust dependencies and build
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "ci-test"
+          shared-key: "ci"
           save-if: true
       - name: Cache Foundry
         uses: actions/cache@v4
@@ -113,7 +117,7 @@ jobs:
       - name: Cache Rust dependencies and build
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "ci-test"
+          shared-key: "ci"
           save-if: true
       - name: Cache Foundry
         uses: actions/cache@v4
@@ -160,7 +164,7 @@ jobs:
       - name: Cache Rust dependencies and build
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "ci-full-integration"
+          shared-key: "ci"
           save-if: true
       - name: Cache Foundry
         uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,37 @@
-FROM rust:1.95-bookworm AS builder
+# ---- Build ----------------------------------------------------------------
+# cargo-chef splits the ~600-crate dependency compile into its own layer, so a
+# source-only change rebuilds just the application crate instead of every
+# dependency. Before this, `COPY . . && cargo build` put all deps in a single
+# RUN layer that any source edit invalidated -- which defeated the buildx layer
+# cache (`cache-from/to: type=gha` in release-image.yml, the local buildx cache
+# in ci.yml's docker job). cargo-chef is installed into the pinned rust image
+# rather than pulled as a separate chef base image, so the build resolves
+# identically on amd64 (CI) and arm64 (Fargate/prod) and stays on the
+# rust:1.95 toolchain we already vet.
+FROM rust:1.95-bookworm AS chef
 WORKDIR /app
+RUN cargo install cargo-chef --locked
+# Copy .cargo/config.toml before the cook step so the RUSTFLAGS it sets
+# (-D warnings) match between the dependency cook and the final build; a
+# mismatch changes the rustc fingerprint and makes the cooked-dependency cache
+# miss.
+COPY .cargo .cargo
 
-# Copy all source files
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Compile dependencies only. This layer is cached until Cargo.toml / Cargo.lock
+# change, so ordinary source edits skip it entirely.
+RUN cargo chef cook --release --recipe-path recipe.json
+# Copy the full source and build only the application crate on top of the
+# already-compiled dependencies.
 COPY . .
 RUN cargo build --release
 
+# ---- Runtime --------------------------------------------------------------
 FROM debian:bookworm-slim AS runtime
 # ca-certificates/libssl3 for HTTPS requests; curl so ECS container health
 # checks can run `curl -f http://localhost:8000/health`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@
 # rust:1.95 toolchain we already vet.
 FROM rust:1.95-bookworm AS chef
 WORKDIR /app
-RUN cargo install cargo-chef --locked
+# Pin the cargo-chef version for reproducible builds: --locked only freezes its
+# transitive deps, so an unpinned install could pull a future release that
+# changes the recipe format or bumps the required Rust toolchain and break the
+# build. 0.1.77 is the version verified against this Dockerfile.
+RUN cargo install cargo-chef --locked --version 0.1.77
 # Copy .cargo/config.toml before the cook step so the RUSTFLAGS it sets
 # (-D warnings) match between the dependency cook and the final build; a
 # mismatch changes the rustc fingerprint and makes the cooked-dependency cache


### PR DESCRIPTION
## Why

Contributors wait too long to learn whether a PR's CI passes. Two things every PR pays for:

1. The parallel lint/test jobs each cold-compile the ~600-crate dependency set, kept in **three separate rust-cache keys** (`ci-lint`, `ci-test`, `ci-full-integration`) so the same dependency build is cached three times over.
2. The `docker` job at the tail recompiles **all ~600 crates again** in the image, because the Dockerfile was `COPY . . && cargo build --release` — one RUN layer that *any* source edit invalidates. That defeats the buildx layer caches already configured (`cache-from/to: type=gha` in `release-image.yml`, the local buildx cache in `ci.yml`'s docker job): they had nothing stable to cache.

## What

- **cargo-chef the Dockerfile.** The dependency compile now lives in its own layer keyed on `Cargo.toml`/`Cargo.lock`, so a source-only change rebuilds just the application crate. cargo-chef is installed into the pinned `rust:1.95-bookworm` (rather than a separate chef base image) so the build resolves identically on amd64 (CI) and arm64 (Fargate/prod). This also makes the **existing** buildx caches effective — no change needed to `release-image.yml` or the `ci.yml` docker job.
- **Unify the rust-cache keys.** All compile jobs now share one `shared-key: "ci"`. rust-cache only caches the registry + compiled dependencies (not our own crates), so sharing is safe and every job restores the same warm dependency build.

The runtime image is byte-for-byte unchanged: same `debian:bookworm-slim` stage, non-root `beaconator` user, `0.0.0.0:8000` bind, `GET /` health, SIGTERM grace 60 / mercy 30.

## Verified locally (Docker 28.3.2, Apple Silicon)

- **Cold build** (deps changed): `cargo chef cook` ~3m, then app crate ~43s → 209 MB image, exit 0.
- **Warm build** (one-line edit to `src/main.rs`, then reverted): the dependency layer is served from cache and only the app recompiles —

  ```
  #13 [builder 1/4] COPY --from=planner /app/recipe.json recipe.json
  #13 CACHED
  #14 [builder 2/4] RUN cargo chef cook --release --recipe-path recipe.json
  #14 CACHED
  #15 [builder 3/4] COPY . .
  #16 [builder 4/4] RUN cargo build --release   # ~50s, app only
  ```

  i.e. the ~3m dependency recompile is skipped entirely on source-only changes. On the slower GHA arm64 release runner (alloy-full + aws-sdk) the saving is considerably larger.
- The rust-cache change proves out on this PR's own CI run; the docker job's existing `curl -f http://localhost:8000/` smoke test still gates.

## Deliberately out of scope (measured follow-ups)

- sccache and/or consolidating the 3 parallel test jobs into a single compile.
- Verify whether `.cargo/config.toml`'s `[lints.clippy] pedantic/nursery` is even honored (`[lints]` is a manifest-only table, so likely dormant) and then remove or gate it.
- Unify `fork-tests.yml`'s `ci-fork` key with `ci`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved build caching across CI checks, reducing repeated Rust dependency compilation.
  * Docker image builds are faster by reusing cached dependency layers more effectively.

* **Chores**
  * Simplified shared caching behavior across Rust-related CI jobs to improve cache reuse and consistency.
  * Updated the Docker build process to use a staged dependency “cookbook” flow, speeding up rebuilds when source changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->