### PR TITLE
ci: parallelize docker + forge cache + mold linker (toward sub-2min CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,9 @@ jobs:
   # Docker build - depends on all test jobs passing
   docker:
     runs-on: ubuntu-latest
-    needs: [format, lint, unit-tests, integration-tests, wallet-tests, full-integration-tests]
+    # No `needs`: the image build runs in parallel with the tests instead of as a
+    # serial tail on the critical path. The `test` aggregate gate below still lists
+    # docker in its needs, so a broken image still blocks the PR.
     services:
       redis:
         image: redis:alpine
@@ -256,7 +258,12 @@ jobs:
             -e WALLET_PRIVATE_KEYS=0000000000000000000000000000000000000000000000000000000000000002,0000000000000000000000000000000000000000000000000000000000000003 \
             -e BEACONATOR_ADMIN_TOKEN=test_admin_token_123 \
             the-beaconator:latest
-          sleep 15
+          # Poll readiness instead of a fixed sleep: return as soon as the server
+          # answers (usually a few seconds) rather than always waiting 15s.
+          for _ in $(seq 1 30); do
+            curl -fsS http://localhost:8000/ >/dev/null 2>&1 && break
+            sleep 1
+          done
           curl -f http://localhost:8000/ || (docker logs test-beaconator && exit 1)
           docker stop test-beaconator
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,15 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Cache compiled mock contracts
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/contracts/out
+            tests/contracts/cache
+          key: forge-${{ runner.os }}-${{ hashFiles('tests/contracts/**/*.sol', 'tests/contracts/foundry.toml') }}
+          restore-keys: |
+            forge-${{ runner.os }}-
       - name: Compile mock contracts
         working-directory: tests/contracts
         run: forge build
@@ -131,6 +140,15 @@ jobs:
 
       # The reserve-floor / pool-top-up route tests spawn an isolated Anvil
       # and deploy the compiled MockUSDC artifact.
+      - name: Cache compiled mock contracts
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/contracts/out
+            tests/contracts/cache
+          key: forge-${{ runner.os }}-${{ hashFiles('tests/contracts/**/*.sol', 'tests/contracts/foundry.toml') }}
+          restore-keys: |
+            forge-${{ runner.os }}-
       - name: Compile mock contracts
         working-directory: tests/contracts
         run: forge build
@@ -176,6 +194,15 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Cache compiled mock contracts
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/contracts/out
+            tests/contracts/cache
+          key: forge-${{ runner.os }}-${{ hashFiles('tests/contracts/**/*.sol', 'tests/contracts/foundry.toml') }}
+          restore-keys: |
+            forge-${{ runner.os }}-
       - name: Compile mock contracts
         working-directory: tests/contracts
         run: forge build

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@
 # rust:1.95 toolchain we already vet.
 FROM rust:1.95-bookworm AS chef
 WORKDIR /app
+# mold: a much faster linker for the final release binary, which links the whole
+# alloy + aws-sdk object graph. Installed once in this cached layer.
+RUN apt-get update && apt-get install -y --no-install-recommends mold && rm -rf /var/lib/apt/lists/*
 # Pin the cargo-chef version for reproducible builds: --locked only freezes its
 # transitive deps, so an unpinned install could pull a future release that
 # changes the recipe format or bumps the required Rust toolchain and break the
@@ -20,6 +23,10 @@ RUN cargo install cargo-chef --locked --version 0.1.77
 # mismatch changes the rustc fingerprint and makes the cooked-dependency cache
 # miss.
 COPY .cargo .cargo
+# Route the linker to mold for the dependency cook AND the final build (the same
+# RUSTFLAGS must apply to both, or the cook cache misses). This ENV overrides
+# .cargo/config.toml's build.rustflags, so keep -D warnings here too.
+ENV RUSTFLAGS="-D warnings -C link-arg=-fuse-ld=mold"
 
 FROM chef AS planner
 COPY . .


### PR DESCRIPTION
Push toward sub-2-minute PR CI, driven by benchmarks rather than guesswork.

## What the benchmark showed (Apple M4; GHA `ubuntu-latest` 4-vCPU ≈ ~3× slower)

| Measurement | M4 |
|---|---|
| Test-job compile floor (deps cached, workspace+test bins fresh) | 12.4s |
| Release crate recompile @ opt-level 3 | 26.5s |
| Link the release binary (alloy graph) | 8.3s |
| Unit-test *execution* | ~0s |

Two facts drive the plan: (1) jobs are **compile/link-bound, not test-bound**; (2) the `docker` job was the tall pole **and ran as a serial tail** (`needs: [all tests]`), so warm wall-clock was ~`max(tests) + docker` ≈ 4min — you can't get near 2min with a heavy job stacked on the end.

## Changes (this PR)

1. **`docker` runs in parallel with the tests** (dropped its `needs`). Wall-clock becomes `max(job)` instead of `tests → docker`. The `test` aggregate gate still lists `docker`, so a broken image still blocks the PR. Also replaced the image smoke test's fixed `sleep 15` with a readiness poll.
2. **Cache the compiled mock contracts** (`tests/contracts/{out,cache}` keyed on the `.sol` sources) so `forge build` is a no-op in the three Foundry jobs when the mocks are unchanged.
3. **mold linker for the release/image build** (Dockerfile). Installed in the cached builder layer; `RUSTFLAGS` routes the linker to it (keeping `-D warnings`) for the cook + final build. Speeds the alloy+aws binary link on the (now-parallel) docker pole. Verified locally: builds with mold 1.10.1 and the binary boots.

## Paired with #85

#85 adds **`opt-level = 2`** for release (I/O-bound service; measured **26.5s → 19.4s**, ~27% off the crate recompile). #85 + this PR together attack the docker pole: parallel + opt-2 compile + mold link.

## Honest scope: why mold is NOT in the CI test jobs (yet)

I deliberately scoped mold to the image build. In the CI test jobs, installing mold costs ~8s (apt) which roughly cancels the link savings, and setting `RUSTFLAGS` cold-invalidates the shared `rust-cache` (`ci` key) — so it's not a clear win and it degrades the next few runs. If we want it there, the right form is a prebuilt-binary install (not apt) and accepting the one-time cache reset — happy to do it as a follow-up if you want to chase the last few seconds.

## Realistic expectation

Warm, with docker parallelized + opt-2 + mold + forge-cache, the tall pole becomes either the heaviest test job or the parallel docker build, landing ≈ **90–120s** — sub-2-min is *achievable on warm runs, borderline*. It won't hold on a run that changes `Cargo.lock`/`Dockerfile` (cache miss → cold). The one bigger lever left if you want it reliably under 2min is **not building the image on every PR** (gate the docker job to Dockerfile/deps changes) — flagged, not done here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image test reliability by checking server readiness instead of using a fixed startup delay.

* **Performance**
  * Accelerated Rust application builds by using the Mold linker.

* **CI Improvements**
  * Added caching for compiled mock contracts to speed up test workflows.
  * Enabled Docker checks to run in parallel with other test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->