### PR TITLE
Add POST /swap_module: batch perp module swaps via the owning Safe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -951,6 +951,7 @@ pub async fn create_rocket() -> Rocket<Build> {
         routes::beacon::create_weighted_sum_composite_beacon_endpoint,
         routes::perp::deploy_perp_for_beacon_endpoint,
         routes::perp::deposit_liquidity_for_perp_endpoint,
+        routes::perp::swap_module_endpoint,
         routes::wallet::fund_guest_wallet,
         routes::wallet::fund_bonus_wallet,
         routes::wallet::top_up_pool,

--- a/src/models/app_state.rs
+++ b/src/models/app_state.rs
@@ -80,6 +80,13 @@ impl ApiEndpoints {
             },
             EndpointInfo {
                 method: "POST".to_string(),
+                path: "/swap_module".to_string(),
+                description: "Swap a module (beacon/pricing/funding/fees/margin_ratios/price_impact) on a batch of perps via the owning Safe (admin)".to_string(),
+                requires_auth: true,
+                status: EndpointStatus::Working,
+            },
+            EndpointInfo {
+                method: "POST".to_string(),
                 path: "/update_beacon".to_string(),
                 description: "Update beacon data (supports both ownable and verifiable beacons)".to_string(),
                 requires_auth: true,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -21,11 +21,11 @@ pub use requests::{
     RegisterBeaconRequest, RegisterBeaconTypeRequest, TopUpPoolRequest, UnregisterBeaconRequest,
     UpdateBeaconRequest, UpdateBeaconTypeRequest, UpdateBeaconWithEcdsaRequest,
 };
-pub use requests::{CreateModularBeaconRequest, ModularBeaconParams};
+pub use requests::{CreateModularBeaconRequest, ModularBeaconParams, SwapModuleRequest};
 pub use responses::{
     ApiResponse, BatchUpdateBeaconResponse, BeaconComponentAddresses, BeaconTypeListResponse,
     BeaconUpdateResult, CreateBeaconResponse, CreateBeaconWithEcdsaResponse,
     CreateModularBeaconResponse, DeployPerpForBeaconResponse, DepositLiquidityForPerpResponse,
-    EcdsaUpdateResponse,
+    EcdsaUpdateResponse, PendingTimelock, SwapModuleResponse,
 };
 pub use wallet::{RedisKeys, WalletInfo, WalletManagerConfig, WalletStatus};

--- a/src/models/requests.rs
+++ b/src/models/requests.rs
@@ -402,3 +402,23 @@ pub struct ModularBeaconParams {
     #[schemars(with = "Option<Vec<String>>")]
     pub initial_m_slow: Option<Vec<u128>>,
 }
+
+/// Swap a module on a batch of per-market Perp contracts (admin only).
+///
+/// Builds the timelocked `submit` + setter call pair for every perp and routes them
+/// through the Safe that owns the perps: executed directly when the beaconator signer
+/// controls a 1-of-1 Safe (testnet), proposed to the Safe Transaction Service otherwise
+/// (mainnet multisig).
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SwapModuleRequest {
+    /// Which module slot to swap: "beacon", "pricing", "funding", "fees",
+    /// "margin_ratios", or "price_impact"
+    pub module_type: String,
+    /// Address of the new module implementation (must be deployed)
+    pub new_module_address: String,
+    /// Perp contract addresses to swap (1..=100)
+    pub perp_addresses: Vec<String>,
+    /// Which half of the timelocked two-step to run: "both" (default), "submit",
+    /// or "execute". "execute" requires a prior submit whose timelock has expired.
+    pub phase: Option<String>,
+}

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -216,3 +216,35 @@ pub struct CreateModularBeaconResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub safe_proposal_hash: Option<String>,
 }
+
+/// A perp whose module swap is submitted but not yet executable (timelock pending)
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct PendingTimelock {
+    /// Perp contract address
+    pub perp_address: String,
+    /// Unix timestamp at which the setter becomes executable (call again with
+    /// phase = "execute" after this time)
+    pub executable_at: u64,
+}
+
+/// Response from a module swap
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SwapModuleResponse {
+    /// How the swap was carried out: "executed" (both batches on-chain),
+    /// "submitted_only" (submit batch on-chain; execute pending timelock or a
+    /// phase="execute" call), or "proposed" (batches proposed to the Safe
+    /// Transaction Service for multisig signing)
+    pub mode: String,
+    /// Transaction hash of the submit batch (Safe tx hash when mode = "proposed")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub submit_tx_hash: Option<String>,
+    /// Transaction hash of the execute batch (Safe tx hash when mode = "proposed")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execute_tx_hash: Option<String>,
+    /// Perps included in the batches
+    pub swapped: Vec<String>,
+    /// Perps skipped because the targeted module slot already equals the new address
+    pub skipped_already_set: Vec<String>,
+    /// Perps whose submit landed but whose timelock has not yet expired
+    pub pending_timelock: Vec<PendingTimelock>,
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -395,5 +395,87 @@ mod component_factories {
 }
 pub use component_factories::*;
 
+// Interfaces for the /swap_module route: Perp timelocked admin functions, the Gnosis Safe
+// that owns every perp, MultiSendCallOnly batching, and one cheap view per module type used
+// as an interface probe before a swap.
+#[allow(clippy::too_many_arguments)]
+mod module_swap_interfaces {
+    alloy::sol! {
+        // Timelocked admin surface of a per-market Perp (perpcity-contracts@v0.1.0).
+        // The setters require a prior `submit(data)` from the owner where `data` is
+        // byte-identical to the eventual setter calldata; `executableAt` tracks pending
+        // submissions and `timelock` the delay (currently 0 on every deployed perp).
+        #[sol(rpc)]
+        interface IPerpAdmin {
+            function owner() external view returns (address);
+            function timelock() external view returns (uint256);
+            function executableAt(bytes calldata data) external view returns (uint256);
+            function modules() external view returns (
+                address beacon,
+                address fees,
+                address funding,
+                address marginRatios,
+                address priceImpact,
+                address pricing
+            );
+            function submit(bytes calldata data) external;
+            function setBeacon(address newBeacon) external;
+            function setPricingModule(address newPricing) external;
+            function setFundingModule(address newFunding) external;
+            function setFeesModule(address newFees) external;
+            function setMarginRatiosModule(address newMarginRatios) external;
+            function setPriceImpactModule(address newPriceImpact) external;
+        }
+
+        // Gnosis Safe v1.4.1 surface used for module swaps. The testnet Safe is 1-of-1 with
+        // the beaconator signer as owner (direct execution); mainnet is a 2-of-N multisig
+        // (proposal via the Safe Transaction Service).
+        #[sol(rpc)]
+        interface IGnosisSafe {
+            function getOwners() external view returns (address[] memory);
+            function getThreshold() external view returns (uint256);
+            function nonce() external view returns (uint256);
+            function execTransaction(
+                address to,
+                uint256 value,
+                bytes calldata data,
+                uint8 operation,
+                uint256 safeTxGas,
+                uint256 baseGas,
+                uint256 gasPrice,
+                address gasToken,
+                address refundReceiver,
+                bytes memory signatures
+            ) external payable returns (bool success);
+        }
+
+        #[sol(rpc)]
+        interface IMultiSendCallOnly {
+            function multiSend(bytes memory transactions) external payable;
+        }
+
+        // One cheap view per module type (src/interfaces/modules/*@v0.1.0), staticcalled with
+        // zeroed arguments as an interface probe: catches wrong-address / wrong-interface
+        // swaps, not semantic errors.
+        #[sol(rpc)]
+        interface IModuleProbes {
+            struct PricePair {
+                uint128 ammPrice;
+                uint128 index;
+            }
+
+            function sqrtPriceBounds(uint256 ammPrice, uint256 index, uint256 emaAmmPrice, uint256 emaIndex)
+                external view returns (uint256 sqrtMin, uint256 sqrtMax);
+            function fairPrice(uint256 ammPrice, uint256 index, uint256 emaAmmPrice, uint256 emaIndex)
+                external view returns (uint256);
+            function fees() external view returns (uint24 cFee, uint24 insFee, uint24 lpFee);
+            function makerMarginRatios() external view returns (uint24 init, uint24 liq, uint24 backstop);
+            function funding(PricePair memory spots, PricePair memory emas) external view returns (int88);
+            function index() external view returns (uint256);
+        }
+    }
+}
+pub use module_swap_interfaces::{IGnosisSafe, IModuleProbes, IMultiSendCallOnly, IPerpAdmin};
+
 // Re-export transaction utilities from services module
 pub use crate::services::transaction::execution::is_nonce_error;

--- a/src/routes/perp.rs
+++ b/src/routes/perp.rs
@@ -6,13 +6,17 @@ use rocket_okapi::openapi;
 use std::str::FromStr;
 use tracing;
 
-use crate::guards::ApiToken;
+use crate::guards::{AdminToken, ApiToken};
 use crate::models::{
     ApiResponse, AppState, DeployPerpForBeaconRequest, DeployPerpForBeaconResponse,
-    DepositLiquidityForPerpRequest, DepositLiquidityForPerpResponse,
+    DepositLiquidityForPerpRequest, DepositLiquidityForPerpResponse, SwapModuleRequest,
+    SwapModuleResponse,
 };
 use crate::routes::IPerpFactory;
-use crate::services::perp::{deploy_perp_for_beacon, deposit_liquidity_for_perp};
+use crate::services::perp::{
+    ModuleType, SwapModuleError, SwapPhase, deploy_perp_for_beacon, deposit_liquidity_for_perp,
+    swap_module,
+};
 
 /// Derive a deterministic 32-byte salt from the deploy request. Reusing this salt on retry
 /// causes `LibClone.cloneDeterministic` inside PerpFactory.createPerp to revert if the previous
@@ -252,6 +256,95 @@ pub async fn deposit_liquidity_for_perp_endpoint(
             tracing::error!("  - Margin amount: {} USDC", request.margin_amount_usdc);
             tracing::error!("  - PerpFactory address: {}", state.contracts.perp_factory);
 
+            Err(Status::InternalServerError)
+        }
+    }
+}
+
+/// Swaps a module on a batch of per-market Perp contracts (admin only).
+///
+/// Runs the timelocked `submit` + setter two-step for every perp through the Safe
+/// that owns them: executed directly when the beaconator signer controls a 1-of-1
+/// Safe (testnet), proposed to the Safe Transaction Service otherwise (mainnet).
+/// Perps already set to the new address are skipped, so retries are idempotent.
+#[openapi(tag = "Perpetual")]
+#[post("/swap_module", data = "<request>")]
+pub async fn swap_module_endpoint(
+    request: Json<SwapModuleRequest>,
+    _token: AdminToken,
+    state: &State<AppState>,
+) -> Result<Json<ApiResponse<SwapModuleResponse>>, Status> {
+    tracing::info!("Received request: POST /swap_module");
+
+    let module_type = match ModuleType::parse(&request.module_type) {
+        Some(m) => m,
+        None => {
+            tracing::error!("Invalid module_type '{}'", request.module_type);
+            return Err(Status::BadRequest);
+        }
+    };
+
+    let new_module = match Address::from_str(&request.new_module_address) {
+        Ok(addr) => addr,
+        Err(e) => {
+            tracing::error!(
+                "Invalid new_module_address '{}': {e}",
+                request.new_module_address
+            );
+            return Err(Status::BadRequest);
+        }
+    };
+
+    let phase = match SwapPhase::parse(request.phase.as_deref()) {
+        Some(p) => p,
+        None => {
+            tracing::error!(
+                "Invalid phase '{:?}': expected both | submit | execute",
+                request.phase
+            );
+            return Err(Status::BadRequest);
+        }
+    };
+
+    let mut perps = Vec::with_capacity(request.perp_addresses.len());
+    for raw in &request.perp_addresses {
+        match Address::from_str(raw) {
+            Ok(addr) => perps.push(addr),
+            Err(e) => {
+                tracing::error!("Invalid perp address '{raw}': {e}");
+                return Err(Status::BadRequest);
+            }
+        }
+    }
+
+    match swap_module(state, module_type, new_module, perps, phase).await {
+        Ok(response) => {
+            let message = match response.mode.as_str() {
+                "executed" => "Module swap executed",
+                "submitted_only" => "Module swap submitted; execution pending",
+                _ => "Module swap proposed to the Safe Transaction Service",
+            };
+            tracing::info!(
+                "{message}: {} swapped, {} skipped",
+                response.swapped.len(),
+                response.skipped_already_set.len()
+            );
+            Ok(Json(ApiResponse {
+                success: true,
+                data: Some(response),
+                message: message.to_string(),
+            }))
+        }
+        Err(SwapModuleError::Validation(msg)) => {
+            tracing::error!("swap_module validation failed: {msg}");
+            Ok(Json(ApiResponse {
+                success: false,
+                data: None,
+                message: msg,
+            }))
+        }
+        Err(SwapModuleError::Internal(msg)) => {
+            tracing::error!("swap_module failed: {msg}");
             Err(Status::InternalServerError)
         }
     }

--- a/src/services/beacon/core.rs
+++ b/src/services/beacon/core.rs
@@ -260,6 +260,7 @@ pub async fn register_beacon_with_registry(
                 state.provider.chain_id,
                 registry_address,
                 &calldata,
+                0,
                 nonce,
                 &state.wallets.signer,
             )
@@ -591,6 +592,7 @@ pub async fn unregister_beacon_with_registry(
                 state.provider.chain_id,
                 registry_address,
                 &calldata,
+                0,
                 nonce,
                 &state.wallets.signer,
             )

--- a/src/services/perp/mod.rs
+++ b/src/services/perp/mod.rs
@@ -1,5 +1,7 @@
 pub mod core;
+pub mod module_swap;
 pub mod validation;
 
 pub use core::*;
+pub use module_swap::*;
 pub use validation::*;

--- a/src/services/perp/module_swap.rs
+++ b/src/services/perp/module_swap.rs
@@ -1,0 +1,751 @@
+//! Batch module swaps on per-market Perp contracts via the owning Gnosis Safe.
+//!
+//! Every deployed Perp (perpcity-contracts@v0.1.0) exposes six timelocked module
+//! setters gated by a two-step: the owner calls `submit(data)`, then after
+//! `timelock` seconds anyone may call the setter with calldata byte-identical to
+//! the submitted `data`. Every perp is owned by a Gnosis Safe, so both steps are
+//! MultiSendCallOnly batches routed through `Safe.execTransaction`:
+//!
+//! - Testnet: the Safe is 1-of-1 and its sole owner is the beaconator signer.
+//!   The signer signs the Safe tx hash (EIP-712) and a KMS pool wallet
+//!   broadcasts `execTransaction` — the signer itself never sends transactions.
+//! - Mainnet: the Safe is a 2-of-N multisig. The batches are proposed to the
+//!   Safe Transaction Service and humans co-sign + execute them in the Safe UI.
+//!
+//! The path is auto-detected from `getOwners()` / `getThreshold()`.
+
+use alloy::primitives::{Address, Bytes, U256, address};
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
+use alloy::signers::Signer;
+use alloy::sol_types::SolCall;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::time::timeout;
+use tracing;
+
+use crate::models::{AppState, PendingTimelock, SwapModuleResponse};
+use crate::routes::{IGnosisSafe, IModuleProbes, IMultiSendCallOnly, IPerpAdmin};
+use crate::services::safe::SafeTransactionService;
+
+/// Canonical Safe MultiSendCallOnly v1.3.0 — the same address on Arbitrum One
+/// and Arbitrum Sepolia (deterministic deployment).
+pub const MULTI_SEND_CALL_ONLY: Address = address!("9641d764fc13c8B624c04430C7356C1C7C8102e2");
+
+/// Upper bound on perps per request. Bounds calldata size and blast radius, not
+/// gas: the 52-perp submit batch executed on 2026-07-23 used ~2.0M gas.
+pub const MAX_PERPS_PER_REQUEST: usize = 100;
+
+const RECEIPT_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Safe transaction operation values.
+const OPERATION_CALL: u8 = 0;
+const OPERATION_DELEGATECALL: u8 = 1;
+
+/// The module slot to swap. Mirrors the `Modules` struct in
+/// perpcity-contracts@v0.1.0 `SharedStructs.sol`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleType {
+    Beacon,
+    Pricing,
+    Funding,
+    Fees,
+    MarginRatios,
+    PriceImpact,
+}
+
+impl ModuleType {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "beacon" => Some(Self::Beacon),
+            "pricing" => Some(Self::Pricing),
+            "funding" => Some(Self::Funding),
+            "fees" => Some(Self::Fees),
+            "margin_ratios" => Some(Self::MarginRatios),
+            "price_impact" => Some(Self::PriceImpact),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Beacon => "beacon",
+            Self::Pricing => "pricing",
+            Self::Funding => "funding",
+            Self::Fees => "fees",
+            Self::MarginRatios => "margin_ratios",
+            Self::PriceImpact => "price_impact",
+        }
+    }
+
+    /// Calldata of the perp's setter for this slot — the bytes that must first be
+    /// `submit`ted and then re-sent verbatim as the setter call.
+    pub fn setter_calldata(&self, new_module: Address) -> Vec<u8> {
+        match self {
+            Self::Beacon => IPerpAdmin::setBeaconCall {
+                newBeacon: new_module,
+            }
+            .abi_encode(),
+            Self::Pricing => IPerpAdmin::setPricingModuleCall {
+                newPricing: new_module,
+            }
+            .abi_encode(),
+            Self::Funding => IPerpAdmin::setFundingModuleCall {
+                newFunding: new_module,
+            }
+            .abi_encode(),
+            Self::Fees => IPerpAdmin::setFeesModuleCall {
+                newFees: new_module,
+            }
+            .abi_encode(),
+            Self::MarginRatios => IPerpAdmin::setMarginRatiosModuleCall {
+                newMarginRatios: new_module,
+            }
+            .abi_encode(),
+            Self::PriceImpact => IPerpAdmin::setPriceImpactModuleCall {
+                newPriceImpact: new_module,
+            }
+            .abi_encode(),
+        }
+    }
+}
+
+/// Which half of the timelocked two-step to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwapPhase {
+    Both,
+    Submit,
+    Execute,
+}
+
+impl SwapPhase {
+    pub fn parse(s: Option<&str>) -> Option<Self> {
+        match s {
+            None | Some("both") => Some(Self::Both),
+            Some("submit") => Some(Self::Submit),
+            Some("execute") => Some(Self::Execute),
+            _ => None,
+        }
+    }
+}
+
+/// Errors split by who is at fault: `Validation` maps to a caller-visible
+/// failure message (bad input / preconditions), `Internal` to a 500.
+#[derive(Debug)]
+pub enum SwapModuleError {
+    Validation(String),
+    Internal(String),
+}
+
+impl SwapModuleError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Validation(m) | Self::Internal(m) => m,
+        }
+    }
+}
+
+/// One MultiSendCallOnly item: `operation (1) ++ to (20) ++ value (32) ++
+/// dataLength (32) ++ data`.
+pub fn multisend_item(to: Address, data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(85 + data.len());
+    out.push(OPERATION_CALL);
+    out.extend_from_slice(to.as_slice());
+    out.extend_from_slice(&U256::ZERO.to_be_bytes::<32>());
+    out.extend_from_slice(&U256::from(data.len()).to_be_bytes::<32>());
+    out.extend_from_slice(data);
+    out
+}
+
+/// Concatenated MultiSend items calling `data` on every perp.
+pub fn build_batch(perps: &[Address], data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(perps.len() * (85 + data.len()));
+    for perp in perps {
+        out.extend_from_slice(&multisend_item(*perp, data));
+    }
+    out
+}
+
+/// `submit(bytes)` calldata wrapping the setter calldata.
+pub fn submit_calldata(setter: &[u8]) -> Vec<u8> {
+    IPerpAdmin::submitCall {
+        data: Bytes::copy_from_slice(setter),
+    }
+    .abi_encode()
+}
+
+/// Full `multiSend(bytes)` calldata for a batch — the `data` argument of
+/// `Safe.execTransaction` (and the bytes the Safe tx hash commits to).
+pub fn multisend_calldata(batch: &[u8]) -> Vec<u8> {
+    IMultiSendCallOnly::multiSendCall {
+        transactions: Bytes::copy_from_slice(batch),
+    }
+    .abi_encode()
+}
+
+struct PerpChecks {
+    timelock: u64,
+    executable_at: u64,
+}
+
+/// Swap `module_type` to `new_module` on every perp in `perps`.
+pub async fn swap_module(
+    state: &AppState,
+    module_type: ModuleType,
+    new_module: Address,
+    perps: Vec<Address>,
+    phase: SwapPhase,
+) -> Result<SwapModuleResponse, SwapModuleError> {
+    let safe_config = state.contracts.safe.as_ref().ok_or_else(|| {
+        SwapModuleError::Validation(
+            "SAFE_ADDRESS is not configured; module swaps go through the Safe that owns the perps"
+                .to_string(),
+        )
+    })?;
+    let safe_address = safe_config.address;
+
+    if perps.is_empty() || perps.len() > MAX_PERPS_PER_REQUEST {
+        return Err(SwapModuleError::Validation(format!(
+            "perp_addresses must contain 1..={MAX_PERPS_PER_REQUEST} entries, got {}",
+            perps.len()
+        )));
+    }
+
+    let provider = &state.provider.read_provider;
+
+    // New module must be a deployed contract.
+    let code = provider
+        .get_code_at(new_module)
+        .await
+        .map_err(|e| SwapModuleError::Internal(format!("Failed to read module code: {e}")))?;
+    if code.is_empty() {
+        return Err(SwapModuleError::Validation(format!(
+            "new_module_address {new_module} has no deployed code"
+        )));
+    }
+
+    // Interface probe: the type-specific view must not revert with zeroed args.
+    probe_module(state, module_type, new_module).await?;
+
+    let setter = module_type.setter_calldata(new_module);
+
+    // Per-perp preconditions. Sequential reads: bounded by MAX_PERPS_PER_REQUEST
+    // and this is an operator route, not a hot path.
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| SwapModuleError::Internal(format!("System clock error: {e}")))?
+        .as_secs();
+    let mut targets: Vec<Address> = Vec::new();
+    let mut checks: Vec<PerpChecks> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+    for perp in &perps {
+        match check_perp(state, *perp, safe_address, module_type, new_module, &setter).await {
+            Ok(None) => skipped.push(perp.to_checksum(None)),
+            Ok(Some(c)) => {
+                if phase == SwapPhase::Execute {
+                    if c.executable_at == 0 {
+                        failures.push(format!(
+                            "{}: no pending submit for this swap (run phase=submit first)",
+                            perp.to_checksum(None)
+                        ));
+                        continue;
+                    }
+                    if c.executable_at > now {
+                        failures.push(format!(
+                            "{}: timelock not expired (executable at {})",
+                            perp.to_checksum(None),
+                            c.executable_at
+                        ));
+                        continue;
+                    }
+                }
+                targets.push(*perp);
+                checks.push(c);
+            }
+            Err(msg) => failures.push(msg),
+        }
+    }
+    if !failures.is_empty() {
+        return Err(SwapModuleError::Validation(format!(
+            "validation failed for {} perp(s): {}",
+            failures.len(),
+            failures.join("; ")
+        )));
+    }
+
+    if targets.is_empty() {
+        return Ok(SwapModuleResponse {
+            mode: "executed".to_string(),
+            submit_tx_hash: None,
+            execute_tx_hash: None,
+            swapped: vec![],
+            skipped_already_set: skipped,
+            pending_timelock: vec![],
+        });
+    }
+
+    let any_timelocked = checks.iter().any(|c| c.timelock > 0);
+
+    // Path detection: direct execution when the beaconator signer alone controls
+    // the Safe, proposal to the Safe Transaction Service otherwise.
+    let safe_contract = IGnosisSafe::new(safe_address, provider.as_ref());
+    let owners = safe_contract
+        .getOwners()
+        .call()
+        .await
+        .map_err(|e| SwapModuleError::Internal(format!("Failed to read Safe owners: {e}")))?;
+    let threshold =
+        safe_contract.getThreshold().call().await.map_err(|e| {
+            SwapModuleError::Internal(format!("Failed to read Safe threshold: {e}"))
+        })?;
+    let direct = threshold == U256::from(1) && owners.contains(&state.wallets.signer_address);
+
+    let submit_batch = build_batch(&targets, &submit_calldata(&setter));
+    let exec_batch = build_batch(&targets, &setter);
+
+    tracing::info!(
+        "swap_module: {} -> {} on {} perp(s) ({} skipped), phase {:?}, path {}",
+        module_type.as_str(),
+        new_module,
+        targets.len(),
+        skipped.len(),
+        phase,
+        if direct { "direct" } else { "propose" },
+    );
+
+    if direct {
+        swap_direct(
+            state,
+            safe_address,
+            module_type,
+            phase,
+            any_timelocked,
+            &targets,
+            &setter,
+            submit_batch,
+            exec_batch,
+            skipped,
+        )
+        .await
+    } else {
+        swap_propose(
+            state,
+            safe_address,
+            phase,
+            &targets,
+            &setter,
+            submit_batch,
+            exec_batch,
+            skipped,
+        )
+        .await
+    }
+}
+
+/// Staticcall the module-type-specific view with zeroed arguments.
+async fn probe_module(
+    state: &AppState,
+    module_type: ModuleType,
+    new_module: Address,
+) -> Result<(), SwapModuleError> {
+    let provider = state.provider.read_provider.as_ref();
+    let probes = IModuleProbes::new(new_module, provider);
+    let zero_pair = IModuleProbes::PricePair {
+        ammPrice: 0,
+        index: 0,
+    };
+    let result = match module_type {
+        ModuleType::Beacon => probes.index().call().await.map(|_| ()),
+        ModuleType::Pricing => probes
+            .fairPrice(U256::ZERO, U256::ZERO, U256::ZERO, U256::ZERO)
+            .call()
+            .await
+            .map(|_| ()),
+        ModuleType::Funding => probes
+            .funding(zero_pair.clone(), zero_pair)
+            .call()
+            .await
+            .map(|_| ()),
+        ModuleType::Fees => probes.fees().call().await.map(|_| ()),
+        ModuleType::MarginRatios => probes.makerMarginRatios().call().await.map(|_| ()),
+        ModuleType::PriceImpact => probes
+            .sqrtPriceBounds(U256::ZERO, U256::ZERO, U256::ZERO, U256::ZERO)
+            .call()
+            .await
+            .map(|_| ()),
+    };
+    result.map_err(|e| {
+        SwapModuleError::Validation(format!(
+            "new_module_address {new_module} failed the {} interface probe: {e}",
+            module_type.as_str()
+        ))
+    })
+}
+
+/// Validate one perp. `Ok(None)` means the slot already holds the new module
+/// (skip); `Ok(Some(checks))` carries its timelock state.
+async fn check_perp(
+    state: &AppState,
+    perp: Address,
+    safe_address: Address,
+    module_type: ModuleType,
+    new_module: Address,
+    setter: &[u8],
+) -> Result<Option<PerpChecks>, String> {
+    let provider = state.provider.read_provider.as_ref();
+    let perp_contract = IPerpAdmin::new(perp, provider);
+
+    let owner = perp_contract
+        .owner()
+        .call()
+        .await
+        .map_err(|e| format!("{}: failed to read owner (is this a Perp?): {e}", perp))?;
+    if owner != safe_address {
+        return Err(format!(
+            "{}: owned by {owner}, not the configured Safe {safe_address}",
+            perp.to_checksum(None)
+        ));
+    }
+
+    let modules = perp_contract
+        .modules()
+        .call()
+        .await
+        .map_err(|e| format!("{}: failed to read modules: {e}", perp))?;
+    let current = match module_type {
+        ModuleType::Beacon => modules.beacon,
+        ModuleType::Fees => modules.fees,
+        ModuleType::Funding => modules.funding,
+        ModuleType::MarginRatios => modules.marginRatios,
+        ModuleType::PriceImpact => modules.priceImpact,
+        ModuleType::Pricing => modules.pricing,
+    };
+    if current == new_module {
+        return Ok(None);
+    }
+
+    let timelock = perp_contract
+        .timelock()
+        .call()
+        .await
+        .map_err(|e| format!("{}: failed to read timelock: {e}", perp))?;
+    let executable_at = perp_contract
+        .executableAt(Bytes::copy_from_slice(setter))
+        .call()
+        .await
+        .map_err(|e| format!("{}: failed to read executableAt: {e}", perp))?;
+
+    Ok(Some(PerpChecks {
+        timelock: timelock.saturating_to::<u64>(),
+        executable_at: executable_at.saturating_to::<u64>(),
+    }))
+}
+
+/// Sign the Safe tx hash with the beaconator signer and return the 65-byte
+/// `r ++ s ++ v` signature Safe expects for a single ECDSA owner signature.
+async fn sign_safe_tx(
+    state: &AppState,
+    safe_address: Address,
+    ms_calldata: &[u8],
+    nonce: u64,
+) -> Result<Vec<u8>, SwapModuleError> {
+    let hash = SafeTransactionService::encode_safe_tx_hash(
+        safe_address,
+        state.provider.chain_id,
+        MULTI_SEND_CALL_ONLY,
+        ms_calldata,
+        OPERATION_DELEGATECALL,
+        nonce,
+    );
+    let signature = state
+        .wallets
+        .signer
+        .sign_hash(&hash)
+        .await
+        .map_err(|e| SwapModuleError::Internal(format!("Failed to sign Safe tx hash: {e}")))?;
+    let mut sig = Vec::with_capacity(65);
+    sig.extend_from_slice(&signature.r().to_be_bytes::<32>());
+    sig.extend_from_slice(&signature.s().to_be_bytes::<32>());
+    sig.push(if signature.v() { 28 } else { 27 });
+    Ok(sig)
+}
+
+/// Read the on-chain `executableAt` for every target after a submit landed.
+async fn read_pending_timelocks(
+    state: &AppState,
+    targets: &[Address],
+    setter: &[u8],
+) -> Vec<PendingTimelock> {
+    let provider = state.provider.read_provider.as_ref();
+    let mut out = Vec::with_capacity(targets.len());
+    for perp in targets {
+        let executable_at = IPerpAdmin::new(*perp, provider)
+            .executableAt(Bytes::copy_from_slice(setter))
+            .call()
+            .await
+            .map(|v| v.saturating_to::<u64>())
+            .unwrap_or(0);
+        out.push(PendingTimelock {
+            perp_address: perp.to_checksum(None),
+            executable_at,
+        });
+    }
+    out
+}
+
+/// Direct path: signer signs, a pool wallet broadcasts `execTransaction`.
+#[allow(clippy::too_many_arguments)]
+async fn swap_direct(
+    state: &AppState,
+    safe_address: Address,
+    module_type: ModuleType,
+    phase: SwapPhase,
+    any_timelocked: bool,
+    targets: &[Address],
+    setter: &[u8],
+    submit_batch: Vec<u8>,
+    exec_batch: Vec<u8>,
+    skipped: Vec<String>,
+) -> Result<SwapModuleResponse, SwapModuleError> {
+    let wallet_handle = state
+        .wallets
+        .manager
+        .acquire_any_wallet()
+        .await
+        .map_err(|e| SwapModuleError::Internal(format!("Failed to acquire wallet: {e}")))?;
+    let wallet_provider = wallet_handle
+        .build_provider(&state.provider.rpc_url)
+        .map_err(|e| SwapModuleError::Internal(format!("Failed to build provider: {e}")))?;
+    let safe_contract = IGnosisSafe::new(safe_address, &wallet_provider);
+
+    let mut submit_tx_hash: Option<String> = None;
+    let mut execute_tx_hash: Option<String> = None;
+
+    if phase == SwapPhase::Both || phase == SwapPhase::Submit {
+        let hash = send_exec_transaction(
+            state,
+            &wallet_handle,
+            &safe_contract,
+            safe_address,
+            multisend_calldata(&submit_batch),
+            "submit batch",
+        )
+        .await?;
+        submit_tx_hash = Some(format!("{hash:#x}"));
+    }
+
+    let run_execute = match phase {
+        SwapPhase::Submit => false,
+        SwapPhase::Execute => true,
+        SwapPhase::Both => !any_timelocked,
+    };
+
+    if run_execute {
+        let hash = send_exec_transaction(
+            state,
+            &wallet_handle,
+            &safe_contract,
+            safe_address,
+            multisend_calldata(&exec_batch),
+            "execute batch",
+        )
+        .await?;
+        execute_tx_hash = Some(format!("{hash:#x}"));
+        tracing::info!(
+            "swap_module: {} swapped on {} perp(s)",
+            module_type.as_str(),
+            targets.len()
+        );
+        return Ok(SwapModuleResponse {
+            mode: "executed".to_string(),
+            submit_tx_hash,
+            execute_tx_hash,
+            swapped: targets.iter().map(|p| p.to_checksum(None)).collect(),
+            skipped_already_set: skipped,
+            pending_timelock: vec![],
+        });
+    }
+
+    // Submit landed but execution is deferred (explicit phase=submit or a
+    // nonzero timelock): report on-chain executableAt for each target.
+    let pending = read_pending_timelocks(state, targets, setter).await;
+    Ok(SwapModuleResponse {
+        mode: "submitted_only".to_string(),
+        submit_tx_hash,
+        execute_tx_hash,
+        swapped: vec![],
+        skipped_already_set: skipped,
+        pending_timelock: pending,
+    })
+}
+
+/// Sign at the Safe's current on-chain nonce, preflight with `eth_call`, send,
+/// and wait for a successful receipt.
+async fn send_exec_transaction<P: Provider>(
+    state: &AppState,
+    wallet_handle: &crate::services::wallet::WalletHandle,
+    safe_contract: &IGnosisSafe::IGnosisSafeInstance<P>,
+    safe_address: Address,
+    ms_calldata: Vec<u8>,
+    label: &str,
+) -> Result<alloy::primitives::B256, SwapModuleError> {
+    // Read the nonce fresh before each Safe tx: it advances on every successful
+    // execTransaction, including the batch sent immediately before this one.
+    let nonce = IGnosisSafe::new(safe_address, state.provider.read_provider.as_ref())
+        .nonce()
+        .call()
+        .await
+        .map_err(|e| SwapModuleError::Internal(format!("Failed to read Safe nonce: {e}")))?
+        .saturating_to::<u64>();
+
+    let sig = sign_safe_tx(state, safe_address, &ms_calldata, nonce).await?;
+    let call = safe_contract.execTransaction(
+        MULTI_SEND_CALL_ONLY,
+        U256::ZERO,
+        Bytes::from(ms_calldata),
+        OPERATION_DELEGATECALL,
+        U256::ZERO,
+        U256::ZERO,
+        U256::ZERO,
+        Address::ZERO,
+        Address::ZERO,
+        Bytes::from(sig),
+    );
+
+    // Preflight: an eth_call surfaces the revert (with reason) before spending gas.
+    // With all Safe gas params 0 an inner MultiSend failure reverts the whole tx,
+    // so a passing preflight covers every perp in the batch.
+    call.call().await.map_err(|e| {
+        SwapModuleError::Validation(format!("{label} preflight simulation reverted: {e}"))
+    })?;
+
+    wallet_handle
+        .ensure_lock_held()
+        .map_err(SwapModuleError::Internal)?;
+    let pending = call
+        .send()
+        .await
+        .map_err(|e| SwapModuleError::Internal(format!("Failed to send {label}: {e}")))?;
+    let tx_hash = *pending.tx_hash();
+    tracing::info!("swap_module {label} sent: {tx_hash:#x}");
+
+    let receipt = timeout(RECEIPT_TIMEOUT, pending.get_receipt())
+        .await
+        .map_err(|_| {
+            SwapModuleError::Internal(format!(
+                "Timed out waiting for {label} receipt ({tx_hash:#x})"
+            ))
+        })?
+        .map_err(|e| {
+            SwapModuleError::Internal(format!("Failed to get {label} receipt ({tx_hash:#x}): {e}"))
+        })?;
+    if !receipt.status() {
+        return Err(SwapModuleError::Internal(format!(
+            "{label} transaction reverted on-chain: {tx_hash:#x}"
+        )));
+    }
+    Ok(tx_hash)
+}
+
+/// Proposal path: sign and queue the batches on the Safe Transaction Service
+/// for the remaining owners to co-sign and execute in the Safe UI.
+#[allow(clippy::too_many_arguments)]
+async fn swap_propose(
+    state: &AppState,
+    safe_address: Address,
+    phase: SwapPhase,
+    targets: &[Address],
+    setter: &[u8],
+    submit_batch: Vec<u8>,
+    exec_batch: Vec<u8>,
+    skipped: Vec<String>,
+) -> Result<SwapModuleResponse, SwapModuleError> {
+    let safe_config = state.contracts.safe.as_ref().expect("checked by caller");
+    let tx_service_url = safe_config.tx_service_url.as_ref().ok_or_else(|| {
+        SwapModuleError::Validation(
+            "Safe Transaction Service URL is not configured and the signer cannot execute \
+             directly (multisig threshold > 1)"
+                .to_string(),
+        )
+    })?;
+
+    // Preflight the submit calls from the Safe before proposing: catches a wrong
+    // perp list while the batches are still off-chain. The setter calls cannot be
+    // simulated yet — they revert with DataNotTimelocked until the submit batch
+    // executes.
+    if phase == SwapPhase::Both || phase == SwapPhase::Submit {
+        let submit_cd = submit_calldata(setter);
+        for perp in targets {
+            let tx_request = TransactionRequest::default()
+                .from(safe_address)
+                .to(*perp)
+                .input(Bytes::from(submit_cd.clone()).into());
+            state
+                .provider
+                .read_provider
+                .estimate_gas(tx_request)
+                .await
+                .map_err(|e| {
+                    SwapModuleError::Validation(format!(
+                        "{}: submit would revert: {e}",
+                        perp.to_checksum(None)
+                    ))
+                })?;
+        }
+    }
+
+    let safe_service = SafeTransactionService::new(tx_service_url);
+    let mut nonce = safe_service
+        .get_nonce(safe_address)
+        .await
+        .map_err(SwapModuleError::Internal)?;
+
+    let mut submit_tx_hash: Option<String> = None;
+    let mut execute_tx_hash: Option<String> = None;
+
+    if phase == SwapPhase::Both || phase == SwapPhase::Submit {
+        let hash = safe_service
+            .propose_transaction(
+                safe_address,
+                state.provider.chain_id,
+                MULTI_SEND_CALL_ONLY,
+                &multisend_calldata(&submit_batch),
+                OPERATION_DELEGATECALL,
+                nonce,
+                &state.wallets.signer,
+            )
+            .await
+            .map_err(SwapModuleError::Internal)?;
+        submit_tx_hash = Some(format!("{hash:#x}"));
+        nonce += 1;
+    }
+
+    if phase == SwapPhase::Both || phase == SwapPhase::Execute {
+        let hash = safe_service
+            .propose_transaction(
+                safe_address,
+                state.provider.chain_id,
+                MULTI_SEND_CALL_ONLY,
+                &multisend_calldata(&exec_batch),
+                OPERATION_DELEGATECALL,
+                nonce,
+                &state.wallets.signer,
+            )
+            .await
+            .map_err(SwapModuleError::Internal)?;
+        execute_tx_hash = Some(format!("{hash:#x}"));
+    }
+
+    tracing::info!(
+        "swap_module: proposed batches to Safe Transaction Service for {} perp(s)",
+        targets.len()
+    );
+    Ok(SwapModuleResponse {
+        mode: "proposed".to_string(),
+        submit_tx_hash,
+        execute_tx_hash,
+        swapped: targets.iter().map(|p| p.to_checksum(None)).collect(),
+        skipped_already_set: skipped,
+        pending_timelock: vec![],
+    })
+}

--- a/src/services/safe.rs
+++ b/src/services/safe.rs
@@ -155,11 +155,15 @@ impl SafeTransactionService {
     /// This follows the Gnosis Safe EIP-712 signing scheme:
     /// - Domain: {chainId, verifyingContract: safeAddress}
     /// - SafeTx type with all gas/payment fields set to 0
+    ///
+    /// `operation` is 0 (CALL) for a direct call to `to`, 1 (DELEGATECALL) for
+    /// MultiSend batches.
     pub fn encode_safe_tx_hash(
         safe_address: Address,
         chain_id: u64,
         to: Address,
         data: &[u8],
+        operation: u8,
         nonce: u64,
     ) -> B256 {
         // EIP-712 domain separator
@@ -183,13 +187,15 @@ impl SafeTransactionService {
         let zero_u256 = U256::ZERO.to_be_bytes::<32>();
         let zero_address = B256::ZERO;
 
+        let operation_u256 = U256::from(operation).to_be_bytes::<32>();
+
         let struct_hash = keccak256(
             [
                 safe_tx_type_hash.as_slice(),              // typeHash
                 &B256::left_padding_from(to.as_slice()).0, // to
                 &zero_u256,                                // value = 0
                 data_hash.as_slice(),                      // keccak256(data)
-                &zero_u256,                                // operation = 0 (CALL)
+                &operation_u256,                           // operation
                 &zero_u256,                                // safeTxGas = 0
                 &zero_u256,                                // baseGas = 0
                 &zero_u256,                                // gasPrice = 0
@@ -215,16 +221,19 @@ impl SafeTransactionService {
     ///
     /// Signs the transaction with the provided signer and submits it.
     /// The signer must be one of the Safe owners.
+    #[allow(clippy::too_many_arguments)]
     pub async fn propose_transaction(
         &self,
         safe_address: Address,
         chain_id: u64,
         to: Address,
         data: &[u8],
+        operation: u8,
         nonce: u64,
         signer: &PrivateKeySigner,
     ) -> Result<B256, String> {
-        let safe_tx_hash = Self::encode_safe_tx_hash(safe_address, chain_id, to, data, nonce);
+        let safe_tx_hash =
+            Self::encode_safe_tx_hash(safe_address, chain_id, to, data, operation, nonce);
 
         // Sign the hash
         let signature = signer
@@ -244,7 +253,7 @@ impl SafeTransactionService {
             to: to.to_checksum(None),
             value: "0".to_string(),
             data: format!("0x{}", hex::encode(data)),
-            operation: 0,
+            operation,
             safe_tx_gas: "0".to_string(),
             base_gas: "0".to_string(),
             gas_price: "0".to_string(),

--- a/tests/unit_tests/mod.rs
+++ b/tests/unit_tests/mod.rs
@@ -15,6 +15,7 @@ pub mod unregister_beacon_route_tests;
 // pub mod services_transaction_execution_comprehensive_tests; // Removed - nonce management obsolete with WalletManager
 pub mod factory_beacon_tests;
 pub mod modular_beacon_tests;
+pub mod module_swap_tests;
 pub mod touch_tests;
 pub mod transaction_events_tests;
 pub mod transaction_execution_tests;

--- a/tests/unit_tests/module_swap_tests.rs
+++ b/tests/unit_tests/module_swap_tests.rs
@@ -1,0 +1,186 @@
+// Module swap encoding tests.
+//
+// Golden vectors come from real Arbitrum Sepolia transactions, not from the
+// implementation under test:
+// - The 2026-07-03 priceImpact exec batch
+//   0xfb01a3da9125988a685b36e1e9e5adf2383eb14299054b2c72b41d024dd123cd
+//   (Safe execTransaction -> MultiSendCallOnly, 54 setter calls)
+// - The 2026-07-23 submit + execute batches
+//   0x0e9a9ac85a6c65707b1a347e38fbffe1d8fbbbd60606c539a6359a5ef444b1b7 /
+//   0x7d2c2e0139073d31a28aeb1a7256a8918731d66085b7273f2fcbb4a30ad9c587
+//   (52 perps swapped to 0xdA88...bD889)
+// - EIP-712 Safe tx hashes cross-checked against the deployed testnet Safe's
+//   own getTransactionHash view (Safe v1.4.1 at 0x6D82...13e7).
+
+use alloy::primitives::{Address, address};
+use the_beaconator::services::perp::module_swap::{
+    MULTI_SEND_CALL_ONLY, ModuleType, SwapPhase, build_batch, multisend_calldata, multisend_item,
+    submit_calldata,
+};
+use the_beaconator::services::safe::SafeTransactionService;
+
+const NEW_MODULE: Address = address!("da88b0e8204c671106cfa8db98c69fa9019bd889");
+const PERP: Address = address!("a77de9df6e08beb8f523153dd0110465190526e3");
+const TESTNET_SAFE: Address = address!("6D826eD4097b19373b11aca5B00F378Af61C13e7");
+
+/// setPriceImpactModule(0xdA88...bD889) calldata as it appears in the real
+/// 2026-07-03 / 2026-07-23 batches.
+const SETTER_HEX: &str = "a79cae0c000000000000000000000000da88b0e8204c671106cfa8db98c69fa9019bd889";
+
+#[test]
+fn test_setter_calldata_matches_onchain_payload() {
+    let calldata = ModuleType::PriceImpact.setter_calldata(NEW_MODULE);
+    assert_eq!(hex::encode(&calldata), SETTER_HEX);
+}
+
+#[test]
+fn test_setter_selectors() {
+    // Selectors of the six deployed timelocked setters (perpcity-contracts@v0.1.0).
+    let cases = [
+        (ModuleType::Beacon, "d42afb56"),
+        (ModuleType::Pricing, "05d719f1"),
+        (ModuleType::Funding, "348519fe"),
+        (ModuleType::Fees, "f7e39255"),
+        (ModuleType::MarginRatios, "717f1709"),
+        (ModuleType::PriceImpact, "a79cae0c"),
+    ];
+    for (module_type, expected) in cases {
+        let calldata = module_type.setter_calldata(NEW_MODULE);
+        assert_eq!(
+            hex::encode(&calldata[..4]),
+            expected,
+            "selector mismatch for {}",
+            module_type.as_str()
+        );
+        assert_eq!(calldata.len(), 36);
+    }
+}
+
+#[test]
+fn test_submit_calldata_matches_onchain_payload() {
+    // submit(bytes) wrapping the setter calldata, as sent in the 2026-07-23
+    // submit batch: selector ef7fa71b, offset 0x20, length 0x24, payload padded
+    // to a 32-byte boundary.
+    let setter = ModuleType::PriceImpact.setter_calldata(NEW_MODULE);
+    let calldata = submit_calldata(&setter);
+    let expected = format!(
+        "ef7fa71b\
+         0000000000000000000000000000000000000000000000000000000000000020\
+         0000000000000000000000000000000000000000000000000000000000000024\
+         {SETTER_HEX}\
+         00000000000000000000000000000000000000000000000000000000"
+    );
+    assert_eq!(hex::encode(&calldata), expected);
+}
+
+#[test]
+fn test_multisend_item_matches_onchain_batch() {
+    // First item of the real 2026-07-03 exec batch: operation 00, the perp
+    // address, zero value, length 0x24, then the setter calldata.
+    let setter = ModuleType::PriceImpact.setter_calldata(NEW_MODULE);
+    let item = multisend_item(PERP, &setter);
+    let expected = format!(
+        "00\
+         a77de9df6e08beb8f523153dd0110465190526e3\
+         0000000000000000000000000000000000000000000000000000000000000000\
+         0000000000000000000000000000000000000000000000000000000000000024\
+         {SETTER_HEX}"
+    );
+    assert_eq!(hex::encode(&item), expected);
+}
+
+#[test]
+fn test_build_batch_concatenates_items() {
+    let setter = ModuleType::PriceImpact.setter_calldata(NEW_MODULE);
+    let other: Address = address!("dd0ce5a9f8e60fa95b2a82c9b45847c1532acbf4");
+    let batch = build_batch(&[PERP, other], &setter);
+    let expected = [
+        multisend_item(PERP, &setter),
+        multisend_item(other, &setter),
+    ]
+    .concat();
+    assert_eq!(batch, expected);
+    assert_eq!(batch.len(), 2 * (85 + 36));
+}
+
+#[test]
+fn test_multisend_calldata_wraps_batch() {
+    // multiSend(bytes) selector is 8d80ff0a (as in the real execTransaction data).
+    let setter = ModuleType::PriceImpact.setter_calldata(NEW_MODULE);
+    let batch = build_batch(&[PERP], &setter);
+    let calldata = multisend_calldata(&batch);
+    assert_eq!(hex::encode(&calldata[..4]), "8d80ff0a");
+    // ABI: offset word, length word, then the padded batch bytes.
+    let batch_len = u64::from_be_bytes(calldata[60..68].try_into().unwrap());
+    assert_eq!(batch_len as usize, batch.len());
+    assert_eq!(&calldata[68..68 + batch.len()], batch.as_slice());
+}
+
+#[test]
+fn test_multi_send_call_only_address() {
+    // Canonical MultiSendCallOnly v1.3.0 (same on Arbitrum One and Sepolia);
+    // the `to` of the real 2026-07 execTransaction calls.
+    assert_eq!(
+        MULTI_SEND_CALL_ONLY,
+        address!("9641d764fc13c8B624c04430C7356C1C7C8102e2")
+    );
+}
+
+#[test]
+fn test_encode_safe_tx_hash_against_deployed_safe() {
+    // Expected values returned by the deployed testnet Safe's getTransactionHash
+    // for (to=MultiSendCallOnly, value=0, data=0xdeadbeef, operation, all gas
+    // fields 0, nonce=5) on chain 421614 — fetched via cast on 2026-08-10.
+    let data = hex::decode("deadbeef").unwrap();
+    let call_hash = SafeTransactionService::encode_safe_tx_hash(
+        TESTNET_SAFE,
+        421614,
+        MULTI_SEND_CALL_ONLY,
+        &data,
+        0,
+        5,
+    );
+    assert_eq!(
+        hex::encode(call_hash),
+        "0765ad761be1d2048d9946da82668ead065f424946a54dab87f1a383ef9411f3"
+    );
+    let delegatecall_hash = SafeTransactionService::encode_safe_tx_hash(
+        TESTNET_SAFE,
+        421614,
+        MULTI_SEND_CALL_ONLY,
+        &data,
+        1,
+        5,
+    );
+    assert_eq!(
+        hex::encode(delegatecall_hash),
+        "45ce1517a35892bbe74697e5244f6c93c89957d79ccc0f7d6a1d523cedaf24b6"
+    );
+}
+
+#[test]
+fn test_module_type_parse_roundtrip() {
+    for name in [
+        "beacon",
+        "pricing",
+        "funding",
+        "fees",
+        "margin_ratios",
+        "price_impact",
+    ] {
+        let parsed = ModuleType::parse(name).expect("known module type");
+        assert_eq!(parsed.as_str(), name);
+    }
+    assert!(ModuleType::parse("priceImpact").is_none());
+    assert!(ModuleType::parse("").is_none());
+}
+
+#[test]
+fn test_swap_phase_parse() {
+    assert_eq!(SwapPhase::parse(None), Some(SwapPhase::Both));
+    assert_eq!(SwapPhase::parse(Some("both")), Some(SwapPhase::Both));
+    assert_eq!(SwapPhase::parse(Some("submit")), Some(SwapPhase::Submit));
+    assert_eq!(SwapPhase::parse(Some("execute")), Some(SwapPhase::Execute));
+    assert_eq!(SwapPhase::parse(Some("Both")), None);
+    assert_eq!(SwapPhase::parse(Some("all")), None);
+}


### PR DESCRIPTION
## What

Adds an admin-gated `POST /swap_module` route that runs the timelocked `submit` + setter two-step for any of the six perp module slots (`beacon`, `pricing`, `funding`, `fees`, `margin_ratios`, `price_impact`) across a batch of perps, replacing hand-built Safe multisend batches (like the 2026-07 testnet priceImpact rotation to `0xdA88...bD889`).

## How

Both steps are MultiSendCallOnly batches routed through `Safe.execTransaction`, with the path auto-detected from the Safe:

- **Direct execution** (testnet: 1-of-1 Safe owned by the beaconator signer): the signer signs the EIP-712 Safe tx hash and a KMS pool wallet broadcasts — the signer itself never sends, preserving the existing wallet architecture.
- **Proposal** (mainnet: 2-of-N multisig): both batches are proposed to the Safe Transaction Service at consecutive nonces for humans to co-sign and execute in the Safe UI. `SafeTransactionService` gains an `operation` parameter (previously hardcoded to CALL).

Request: `module_type`, `new_module_address`, `perp_addresses[]` (1..=100), optional `phase` (`both`/`submit`/`execute`) for nonzero-timelock futures — pending state lives on-chain in `executableAt`, the service stays stateless.

## Safety

- Preflight before any tx: module bytecode + per-type interface probe, per-perp `owner()` == configured Safe, current-module comparison (already-set perps are skipped, so retries are idempotent), and `eth_call` simulation of each batch. All Safe gas params are 0 so an inner failure reverts the whole batch atomically.
- Encoding locked by golden vectors from the real 2026-07-03/2026-07-23 on-chain batches; EIP-712 hashes cross-checked against the deployed testnet Safe's own `getTransactionHash` (both operation values).

## Testing

- `make fmt-check`, `make lint` (clippy -D warnings), `make test` all green locally.
- 10 new unit tests in `tests/unit_tests/module_swap_tests.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only module swap endpoint for updating Perp modules across multiple contracts.
  * Supports direct execution or Safe-based proposals, including timelocked submission and execution.
  * Reports completed swaps, skipped modules, pending timelocks, and transaction details.
  * Supports six module types with validation and batch-size limits.

* **Bug Fixes**
  * Preserved Safe transaction operation types when hashing and proposing transactions.

* **Tests**
  * Added coverage for calldata encoding, batching, transaction hashes, and swap configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->